### PR TITLE
Make modules in User entity relations

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -50,6 +50,8 @@
     "mcf": "ts-node ./src/api/moduleCondensed/fetch.ts",
     "mg": "ts-node ./src/api/module/get/index.ts",
     "mgc": "ts-node ./src/api/module/get/codes.ts",
-    "pm": "ts-node ./src/api/module/pull.ts"
+    "pm": "ts-node ./src/api/module/pull.ts",
+    "typeorm_ds": "typeorm-ts-node-esm -d ./src/data-source.ts",
+    "migration": "yarn typeorm_ds migration:generate ./src/migrations/migrationName"
   }
 }

--- a/packages/database/src/api/sql/reset/module.ts
+++ b/packages/database/src/api/sql/reset/module.ts
@@ -1,3 +1,3 @@
 import { remove } from '../../../sql/remove'
 
-remove.tables(['degree_modules_required_module', 'module'])
+remove.tables(['user_modules_completed_module', 'user_modules_doing_module', 'degree_modules_required_module', 'module'])

--- a/packages/database/src/data-source.ts
+++ b/packages/database/src/data-source.ts
@@ -15,7 +15,7 @@ export const AppDataSource = new DataSource({
   synchronize: true,
   logging: false,
   entities: [ModuleCondensed, Module, User, Degree],
-  migrations: ['migrations/*.ts'],
+  migrations: ['src/migrations/**/*.ts'],
   subscribers: [],
 })
 

--- a/packages/database/src/data-source.ts
+++ b/packages/database/src/data-source.ts
@@ -15,7 +15,7 @@ export const AppDataSource = new DataSource({
   synchronize: true,
   logging: false,
   entities: [ModuleCondensed, Module, User, Degree],
-  migrations: [],
+  migrations: ['migrations/*.ts'],
   subscribers: [],
 })
 

--- a/packages/database/src/data-source.ts
+++ b/packages/database/src/data-source.ts
@@ -12,7 +12,7 @@ export const AppDataSource = new DataSource({
   username: config.username,
   password: config.password,
   database: config.database,
-  synchronize: true,
+  synchronize: false,
   logging: false,
   entities: [ModuleCondensed, Module, User, Degree],
   migrations: ['src/migrations/**/*.ts'],

--- a/packages/database/src/entity/User.ts
+++ b/packages/database/src/entity/User.ts
@@ -66,8 +66,21 @@ export class User {
         },
       })
 
+      // Relations are not stored in the entity, so they must be explicitly
+      // asked for from the DB
+      const userRepo = AppDataSource.getRepository(User)
+      const user = await userRepo.findOne({
+        where: {
+          id: this.id,
+        },
+        relations: ['modulesCompleted'],
+      })
+      const modulesCompleted = user.modulesCompleted
+
       // check if PrereqTree is fulfilled
-      return utils.checkTree(module.prereqTree, this.modulesCompleted)
+      const completedModulesCodes = modulesCompleted.map((one: Module) => one.moduleCode)
+
+      return utils.checkTree(module.prereqTree, completedModulesCodes)
     })
   }
 

--- a/packages/database/src/migrations/1652629081741-migrationName.ts
+++ b/packages/database/src/migrations/1652629081741-migrationName.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class migrationName1652629081741 implements MigrationInterface {
+    name = 'migrationName1652629081741'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE \`user_modules_completed_module\` (\`userId\` varchar(36) NOT NULL, \`moduleId\` varchar(36) NOT NULL, INDEX \`IDX_8ce9d16fbf596d080147527959\` (\`userId\`), INDEX \`IDX_bdce7ef837336e404ec8b307de\` (\`moduleId\`), PRIMARY KEY (\`userId\`, \`moduleId\`)) ENGINE=InnoDB`);
+        await queryRunner.query(`CREATE TABLE \`user_modules_doing_module\` (\`userId\` varchar(36) NOT NULL, \`moduleId\` varchar(36) NOT NULL, INDEX \`IDX_4b333af5e5071937f7eba70c5d\` (\`userId\`), INDEX \`IDX_a0ac2a1563d827af2e4ccf2442\` (\`moduleId\`), PRIMARY KEY (\`userId\`, \`moduleId\`)) ENGINE=InnoDB`);
+        await queryRunner.query(`ALTER TABLE \`user\` DROP COLUMN \`modulesCompleted\``);
+        await queryRunner.query(`ALTER TABLE \`user\` DROP COLUMN \`modulesDoing\``);
+        await queryRunner.query(`ALTER TABLE \`user_modules_completed_module\` ADD CONSTRAINT \`FK_8ce9d16fbf596d0801475279591\` FOREIGN KEY (\`userId\`) REFERENCES \`user\`(\`id\`) ON DELETE CASCADE ON UPDATE CASCADE`);
+        await queryRunner.query(`ALTER TABLE \`user_modules_completed_module\` ADD CONSTRAINT \`FK_bdce7ef837336e404ec8b307de3\` FOREIGN KEY (\`moduleId\`) REFERENCES \`module\`(\`id\`) ON DELETE CASCADE ON UPDATE CASCADE`);
+        await queryRunner.query(`ALTER TABLE \`user_modules_doing_module\` ADD CONSTRAINT \`FK_4b333af5e5071937f7eba70c5d0\` FOREIGN KEY (\`userId\`) REFERENCES \`user\`(\`id\`) ON DELETE CASCADE ON UPDATE CASCADE`);
+        await queryRunner.query(`ALTER TABLE \`user_modules_doing_module\` ADD CONSTRAINT \`FK_a0ac2a1563d827af2e4ccf24420\` FOREIGN KEY (\`moduleId\`) REFERENCES \`module\`(\`id\`) ON DELETE CASCADE ON UPDATE CASCADE`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE \`user_modules_doing_module\` DROP FOREIGN KEY \`FK_a0ac2a1563d827af2e4ccf24420\``);
+        await queryRunner.query(`ALTER TABLE \`user_modules_doing_module\` DROP FOREIGN KEY \`FK_4b333af5e5071937f7eba70c5d0\``);
+        await queryRunner.query(`ALTER TABLE \`user_modules_completed_module\` DROP FOREIGN KEY \`FK_bdce7ef837336e404ec8b307de3\``);
+        await queryRunner.query(`ALTER TABLE \`user_modules_completed_module\` DROP FOREIGN KEY \`FK_8ce9d16fbf596d0801475279591\``);
+        await queryRunner.query(`ALTER TABLE \`user\` ADD \`modulesDoing\` json NOT NULL`);
+        await queryRunner.query(`ALTER TABLE \`user\` ADD \`modulesCompleted\` json NOT NULL`);
+        await queryRunner.query(`DROP INDEX \`IDX_a0ac2a1563d827af2e4ccf2442\` ON \`user_modules_doing_module\``);
+        await queryRunner.query(`DROP INDEX \`IDX_4b333af5e5071937f7eba70c5d\` ON \`user_modules_doing_module\``);
+        await queryRunner.query(`DROP TABLE \`user_modules_doing_module\``);
+        await queryRunner.query(`DROP INDEX \`IDX_bdce7ef837336e404ec8b307de\` ON \`user_modules_completed_module\``);
+        await queryRunner.query(`DROP INDEX \`IDX_8ce9d16fbf596d080147527959\` ON \`user_modules_completed_module\``);
+        await queryRunner.query(`DROP TABLE \`user_modules_completed_module\``);
+    }
+
+}

--- a/packages/database/tests/entity/user.test.ts
+++ b/packages/database/tests/entity/user.test.ts
@@ -2,7 +2,7 @@ import { setup } from '../setup'
 import { endpoint } from '../../src/data-source'
 import { container, AppDataSource } from '../../src/data-source'
 import { User } from '../../src/entity'
-import { UserProps } from '../../types/modtree'
+import { UserInitProps } from '../../types/modtree'
 
 beforeAll(async () => {
   await setup()
@@ -11,7 +11,7 @@ beforeAll(async () => {
 jest.setTimeout(20000)
 
 test('canTakeModule is successful', async () => {
-  const props: UserProps = {
+  const props: UserInitProps = {
     displayName: 'Nguyen Vu Khang',
     username: 'nvkhang',
     modulesCompleted: ['MA2001'],

--- a/packages/database/types/modtree.d.ts
+++ b/packages/database/types/modtree.d.ts
@@ -6,11 +6,21 @@ export type ModtreeFunctionWithArgs<A extends BaseArgs, T> = (
   args: A
 ) => Promise<T>
 
-export type UserProps = {
+export type UserInitProps = {
   displayName: string
   username: string
   modulesCompleted: string[]
   modulesDoing: string[]
+  matriculationYear: number
+  graduationYear: number
+  graduationSemester: number
+}
+
+export type UserProps = {
+  displayName: string
+  username: string
+  modulesCompleted: Module[]
+  modulesDoing: Module[]
   matriculationYear: number
   graduationYear: number
   graduationSemester: number


### PR DESCRIPTION
In preparation for #46, now properties `modulesCompleted` and `modulesDoing` for a `User` use relations instead of module code strings.