### PR TITLE
Misc

### DIFF
--- a/packages/database/src/repository/DAG.ts
+++ b/packages/database/src/repository/DAG.ts
@@ -86,7 +86,7 @@ async function initialize(props: DAGInitProps): Promise<void> {
       modulesHidden,
     }
     const dag = build(dagProps)
-    await DAGRepository.save(dag)
+    await BaseRepo.save(dag)
   })
 }
 
@@ -149,6 +149,7 @@ async function toggleModule(dag: DAG, moduleCode: string): Promise<void> {
   })
 }
 
+const BaseRepo = AppDataSource.getRepository(DAG)
 export const DAGRepository = Repository.extend({
   initialize,
   build,

--- a/packages/database/src/repository/DAG.ts
+++ b/packages/database/src/repository/DAG.ts
@@ -138,7 +138,8 @@ async function toggleModule(dag: DAG, moduleCode: string): Promise<void> {
 
       retrieved.modulesPlaced.push(module)
     } else {
-      console.log('Module not found in DAG')
+      // throw error if module not found
+      throw new Error('Module not found in DAG')
     }
 
     // update dag so that devs don't need a second query

--- a/packages/database/src/repository/Degree.ts
+++ b/packages/database/src/repository/Degree.ts
@@ -35,7 +35,7 @@ async function initialize(props: Init.DegreeProps): Promise<void> {
       title: props.title,
     }
     const degree = build(degreeProps)
-    await DegreeRepository.save(degree)
+    await BaseRepo.save(degree)
   })
 }
 

--- a/packages/database/src/repository/Module.ts
+++ b/packages/database/src/repository/Module.ts
@@ -44,29 +44,11 @@ function build(props: NM): Module {
 }
 
 /**
- * get all modules in the database
- * @return {Promise<Module[]>}
- */
-async function get(): Promise<Module[]> {
-  const modules = await container(async () => {
-    const modules = await BaseRepo.find().catch((err) => {
-      log.warn('Warning: failed to get Modules from database.')
-      console.log(err)
-    })
-    return modules
-  })
-  if (!modules) {
-    return []
-  }
-  return modules
-}
-
-/**
  * get all module codes from the module table
  * @return {Promise<string[]>}
  */
 async function getCodes(): Promise<string[]> {
-  const modules = await get()
+  const modules = await ModuleRepository.find()
   const codes = modules.map((m) => m.moduleCode)
   return codes
 }

--- a/packages/database/tests/configs/jest.config.ts
+++ b/packages/database/tests/configs/jest.config.ts
@@ -40,7 +40,7 @@ export const k: Config.InitialOptions = {
 
 export const w: Config.InitialOptions = {
   ...base,
-  testMatch: ['**/tests/**/degree.test.ts'],
+  testMatch: ['**/tests/**/dag.test.ts'],
   silent: false,
 }
 

--- a/packages/database/tests/dag.test.ts
+++ b/packages/database/tests/dag.test.ts
@@ -1,4 +1,4 @@
-import { container, endpoint } from '../src/data-source'
+import { AppDataSource, container, endpoint } from '../src/data-source'
 import { DAGInitProps } from '../types/modtree'
 import { Degree, User, Module, DAG } from '../src/entity'
 import {
@@ -152,6 +152,23 @@ describe('DAG.initialize with pullAll = true', () => {
 
       expect(dag.modulesPlaced.length).toEqual(moduleCodes.length)
       expect(dag.modulesHidden.length).toEqual(0)
+    })
+
+    it("Throws error if the module to be toggled is not part of the DAG", async () => {
+      let error
+      await AppDataSource.initialize()
+
+      try {
+        await DAGRepository.toggleModule(dag, 'XXYYZZ')
+      } catch (err) {
+        error = err
+      }
+
+      expect(error).toBeInstanceOf(Error)
+      expect(error.message).toBe('Module not found in DAG')
+
+      await AppDataSource.destroy()
+      await setup()
     })
   })
 })

--- a/packages/database/tests/module.test.ts
+++ b/packages/database/tests/module.test.ts
@@ -1,10 +1,10 @@
 import { container, endpoint } from '../src/data-source'
-import { Module } from '../src/entity'
+import { Module, ModuleCondensed } from '../src/entity'
 import { ModuleRepository } from '../src/repository'
 import { setup, importChecks } from './setup'
 
 importChecks({
-  entities: [Module],
+  entities: [Module, ModuleCondensed],
   repositories: [ModuleRepository],
 })
 
@@ -60,5 +60,14 @@ test('get all modules in database', async () => {
   res.forEach((module) => {
     expect(module).toBeInstanceOf(Module)
   })
+  expect(res.length).toBeGreaterThan(6000)
+})
+
+test('get all module codes in database', async () => {
+  const res = await endpoint(() => container(() => ModuleRepository.getCodes()))
+  if (!res) {
+    return
+  }
+  expect(res).toBeInstanceOf(Array)
   expect(res.length).toBeGreaterThan(6000)
 })


### PR DESCRIPTION
- Removed `ModuleRepository.get()` as `Repository.find()` provides same functionality
- Add test for `ModuleRepository.getCodes()`
- Use `BaseRepo` in DAG and Degree
- `DAG.toggleModules` now throws error if the module code passed in does not correspond to any module in the DAG. Added a test for this too

### Note for `DAG.toggleModules` thrown error

- We can figure out how to deal with thrown errors more elegantly (and maybe standardize with container and endpoint) in future
- This gives us a working template so we can explicitly handle invalid input