### PR TITLE
User methods

### DIFF
--- a/packages/database/src/repository/User.ts
+++ b/packages/database/src/repository/User.ts
@@ -1,7 +1,6 @@
 import { container } from '../data-source'
 import { DataSource, Repository } from 'typeorm'
 import { Init, UserProps } from '../../types/modtree'
-import { ModuleCode } from '../../types/nusmods'
 import { User } from '../entity/User'
 import { Module } from '../entity/Module'
 import { ModuleRepository } from './Module'
@@ -115,9 +114,9 @@ export function UserRepository(database?: DataSource): UserRepository {
         modulesDone: true,
       })
       // 2. get array of module codes of post-reqs (fulfillRequirements)
-      const postReqCodesSet = new Set<ModuleCode>()
+      const postReqCodesSet = new Set<string>()
       user.modulesDone.forEach((module: Module) => {
-        module.fulfillRequirements.forEach((moduleCode: ModuleCode) => {
+        module.fulfillRequirements.forEach((moduleCode: string) => {
           postReqCodesSet.add(moduleCode)
         })
       })

--- a/packages/database/src/repository/User.ts
+++ b/packages/database/src/repository/User.ts
@@ -1,6 +1,7 @@
 import { container } from '../data-source'
 import { DataSource, Repository } from 'typeorm'
 import { Init, UserProps } from '../../types/modtree'
+import { ModuleCode } from '../../types/nusmods'
 import { User } from '../entity/User'
 import { Module } from '../entity/Module'
 import { ModuleRepository } from './Module'
@@ -62,9 +63,9 @@ export function UserRepository(database?: DataSource): UserRepository {
    * Given a module code, checks if user has cleared sufficient pre-requisites.
    * Currently does not check for preclusion.
    *
-   * @param{User} user
-   * @param{string} moduleCode
-   * @return{Promise<boolean>}
+   * @param {User} user
+   * @param {string} moduleCode
+   * @return {Promise<boolean>}
    */
   async function canTakeModule(
     user: User,
@@ -100,6 +101,33 @@ export function UserRepository(database?: DataSource): UserRepository {
   }
 
   /**
+   * List mods a user can take, based on what the user has completed.
+   *
+   * @param {User} user
+   * @param {boolean} includeModsWithoutPrereqs
+   * @return {Promise<Module[]>}
+   */
+  async function eligibleModules(user: User): Promise<Module[] | void> {
+    return await container(db, async () => {
+      // 1. load modulesDone relations
+      await UserRepository(db).loadRelations(user, {
+        modulesDone: true,
+      })
+      // 2. get array of module codes of post-reqs (fulfillRequirements)
+      const postReqCodesSet = new Set<ModuleCode>()
+      user.modulesDone.forEach((module: Module) => {
+        module.fulfillRequirements.forEach((moduleCode: ModuleCode) => {
+          postReqCodesSet.add(moduleCode)
+        })
+      })
+      const postReqCodesArr = Array.from(postReqCodesSet)
+      // 3. get modules
+      const postReqArr = await ModuleRepository(db).findByCodes(postReqCodesArr)
+      return postReqArr
+    })
+  }
+
+  /**
    * @param {string} username
    * @return {Promise<User>}
    */
@@ -115,5 +143,6 @@ export function UserRepository(database?: DataSource): UserRepository {
     initialize,
     loadRelations,
     findOneByUsername,
+    eligibleModules,
   })
 }

--- a/packages/database/src/repository/User.ts
+++ b/packages/database/src/repository/User.ts
@@ -108,23 +108,21 @@ export function UserRepository(database?: DataSource): UserRepository {
    * @return {Promise<Module[]>}
    */
   async function eligibleModules(user: User): Promise<Module[] | void> {
-    return await container(db, async () => {
-      // 1. load modulesDone relations
-      await UserRepository(db).loadRelations(user, {
-        modulesDone: true,
-      })
-      // 2. get array of module codes of post-reqs (fulfillRequirements)
-      const postReqCodesSet = new Set<string>()
-      user.modulesDone.forEach((module: Module) => {
-        module.fulfillRequirements.forEach((moduleCode: string) => {
-          postReqCodesSet.add(moduleCode)
-        })
-      })
-      const postReqCodesArr = Array.from(postReqCodesSet)
-      // 3. get modules
-      const postReqArr = await ModuleRepository(db).findByCodes(postReqCodesArr)
-      return postReqArr
+    // 1. load modulesDone relations
+    await UserRepository(db).loadRelations(user, {
+      modulesDone: true,
     })
+    // 2. get array of module codes of post-reqs (fulfillRequirements)
+    const postReqCodesSet = new Set<string>()
+    user.modulesDone.forEach((module: Module) => {
+      module.fulfillRequirements.forEach((moduleCode: string) => {
+        postReqCodesSet.add(moduleCode)
+      })
+    })
+    const postReqCodesArr = Array.from(postReqCodesSet)
+    // 3. get modules
+    const postReqArr = await ModuleRepository(db).findByCodes(postReqCodesArr)
+    return postReqArr
   }
 
   /**

--- a/packages/database/src/repository/User.ts
+++ b/packages/database/src/repository/User.ts
@@ -19,6 +19,7 @@ interface UserRepository extends Repository<User> {
   canTakeModule(user: User, moduleCode: string): Promise<boolean | void>
   loadRelations: LoadRelations<User>
   findOneByUsername(username: string): Promise<User>
+  eligibleModules(user: User): Promise<Module[] | void>
 }
 
 /**

--- a/packages/database/tests/degree.test.ts
+++ b/packages/database/tests/degree.test.ts
@@ -33,12 +33,7 @@ describe('Degree', () => {
       // retrieve that degree again
       const possiblyNull: Degree | void = await endpoint(db, () =>
         container(db, () =>
-          DegreeRepository(db).findOne({
-            where: {
-              title: props.title,
-            },
-            relations: { modules: true },
-          })
+          DegreeRepository(db).findOneByTitle(props.title)
         )
       )
       // expect degree to be not null, not undefined

--- a/packages/database/tests/user.test.ts
+++ b/packages/database/tests/user.test.ts
@@ -27,12 +27,7 @@ describe('User.canTakeModule', () => {
     await UserRepository(db).initialize(props)
     const res = await endpoint(db, () =>
       container(db, async () => {
-        // find user
-        return await UserRepository(db).findOne({
-          where: {
-            username: props.username,
-          },
-        })
+        return await UserRepository(db).findOneByUsername(props.username)
       })
     )
     expect(res).toBeDefined()
@@ -91,12 +86,7 @@ describe('User.eligibleModules', () => {
     await UserRepository(db).initialize(props)
     const res = await endpoint(db, () =>
       container(db, async () => {
-        // find user
-        return await UserRepository(db).findOne({
-          where: {
-            username: props.username,
-          },
-        })
+        return await UserRepository(db).findOneByUsername(props.username)
       })
     )
     expect(res).toBeDefined()
@@ -112,17 +102,18 @@ describe('User.eligibleModules', () => {
     expect(eligibleModules).toBeDefined()
     if (!eligibleModules) return
     // Get fulfillRequirements of MA2001 (the only module done)
-    const module = await endpoint(db, () =>
+    const modules = await endpoint(db, () =>
       container(db, async () => {
         // find user
-        return await ModuleRepository(db).findOneBy({
-          moduleCode: 'MA2001',
-        })
+        return await ModuleRepository(db).findByCodes(['MA2001'])
       })
     )
-    expect(module).toBeDefined()
-    if (!module) return
-    // compare module codes
+    expect(modules).toBeDefined()
+    if (!modules) return
+    expect(modules).toBeInstanceOf(Array)
+    expect(modules.length).toEqual(1)
+    const module = modules[0]
+    // Compare module codes
     const eligibleModuleCodes = eligibleModules.map((one: Module) => one.moduleCode)
     expect(eligibleModuleCodes.sort()).toEqual(module.fulfillRequirements.sort())
     expect(eligibleModuleCodes.length).toEqual(module.fulfillRequirements.length)


### PR DESCRIPTION
Closes #46. Options 2-4 will be implemented in another PR as an additional config on User.eligibleModuels

### Notes

User.eligibleModules currently only returns modules whose pre-reqs are cleared explicitly. So it does not include most level 1k/2k modules which are SU-able. Ideally there is an option for the user to choose whether they want to include such modules in their search.

1. No option for user (Current)
2. Assume that only modules with blank pre-requisites can be taken by anyone (Efficient, Inaccurate e.g. language modules, ES2660)
3. Assume that all SU-able modules can be taken by anyone (Inefficient, Inaccurate e.g. language modules, mods with MA1301 as pre-req)
4. Use prereqTree to check for prior modules (Inefficient, least inaccurate e.g. language modules, mods with special pre-reqs like grades)
5. Build a new column that states whether module can be taken by anyone or not (Efficient in the long run, same as 4)