### PR TITLE
Misc refactors + GraphRepository.findOneById

### DIFF
--- a/packages/database/src/repository/Graph.ts
+++ b/packages/database/src/repository/Graph.ts
@@ -7,7 +7,7 @@ import { UserRepository } from './User'
 import { DegreeRepository } from './Degree'
 import { Degree } from '../entity/Degree'
 import { User } from '../entity/User'
-import { getDataSource, useLoadRelations } from './base'
+import { getDataSource, useLoadRelations, getRelationNames } from './base'
 import { quickpop, Flatten } from '../utils'
 import type { GraphRepository as Repository } from '../../types/repository'
 
@@ -137,6 +137,23 @@ export function GraphRepository(database?: DataSource): Repository {
     }
 
     await BaseRepo.save(graph)
+  }
+
+  /**
+   * Returns a User with all relations loaded
+   *
+   * @param {string} id
+   * @returns {Promise<Graph>}
+   */
+  async function findOneById(id: string): Promise<Graph> {
+    // get graph by id
+    const graph = await BaseRepo.createQueryBuilder('graph')
+      .where('graph.id = :id', { id })
+      .getOneOrFail()
+    // get relation names
+    const relationNames = getRelationNames(db, Graph)
+    await GraphRepository(db).loadRelations(graph, relationNames)
+    return graph
   }
 
   /**
@@ -276,6 +293,7 @@ export function GraphRepository(database?: DataSource): Repository {
     initialize,
     toggleModule,
     loadRelations,
+    findOneById,
     findOneByUserAndDegreeId,
     findManyByUserAndDegreeId,
     suggestModulesFromOne,

--- a/packages/database/tests/base/defined.test.ts
+++ b/packages/database/tests/base/defined.test.ts
@@ -1,10 +1,11 @@
 import { getSource } from '../../src/data-source'
-import { Module, ModuleCondensed, Degree, User } from '../../src/entity'
+import { Module, ModuleCondensed, Degree, User, Graph } from '../../src/entity'
 import {
   ModuleRepository,
   ModuleCondensedRepository,
   DegreeRepository,
   UserRepository,
+  GraphRepository,
 } from '../../src/repository'
 import { oneUp } from '../../src/utils'
 
@@ -20,6 +21,7 @@ test('All entities are defined', () => {
   expect(ModuleCondensed).toBeDefined()
   expect(Degree).toBeDefined()
   expect(User).toBeDefined()
+  expect(Graph).toBeDefined()
 })
 
 test('All repositories are defined', () => {
@@ -27,4 +29,5 @@ test('All repositories are defined', () => {
   expect(ModuleCondensedRepository(db)).toBeDefined()
   expect(DegreeRepository(db)).toBeDefined()
   expect(UserRepository(db)).toBeDefined()
+  expect(GraphRepository(db)).toBeDefined()
 })

--- a/packages/database/tests/degree/initialize.test.ts
+++ b/packages/database/tests/degree/initialize.test.ts
@@ -26,6 +26,17 @@ describe('Degree.initialize', () => {
     )
   })
 
+  it('Can find same degree (without relations)', async () => {
+    await container(db, () =>
+      DegreeRepository(db)
+        .findOneByTitle(props.title)
+        .then((res) => {
+          expect(res).toBeInstanceOf(Degree)
+          expect(res).toStrictEqual(t.degree)
+        })
+    )
+  })
+
   it('Correctly saves modules', async () => {
     const moduleCodes = t.degree.modules.map(Flatten.module)
     // match relation's module codes to init props' modules codes

--- a/packages/database/tests/graph/initialize/pull-all.test.ts
+++ b/packages/database/tests/graph/initialize/pull-all.test.ts
@@ -29,16 +29,6 @@ beforeAll(() =>
     .then(([user, degree]) => {
       t.user = user
       t.degree = degree
-      return GraphRepository(db).initialize({
-        userId: user.id,
-        degreeId: degree.id,
-        modulesPlacedCodes: [],
-        modulesHiddenCodes: [],
-        pullAll: true,
-      })
-    })
-    .then((graph) => {
-      t.graph = graph
     })
 )
 afterAll(() => teardown(db))

--- a/packages/database/tests/graph/initialize/pull-all.test.ts
+++ b/packages/database/tests/graph/initialize/pull-all.test.ts
@@ -78,7 +78,7 @@ describe('Graph.initialize', () => {
      * all these module codes should show up in the hidden codes
      */
     const hidden = t.graph.modulesHidden.map(Flatten.module)
-    expect(hidden.sort()).toEqual(t.moduleCodes.sort())
+    expect(hidden.sort()).toStrictEqual(t.moduleCodes.sort())
     expect(t.graph.modulesPlaced.length).toEqual(0)
   })
 })

--- a/packages/database/tests/graph/suggest/from-one.test.ts
+++ b/packages/database/tests/graph/suggest/from-one.test.ts
@@ -72,7 +72,7 @@ const expected = [
   'CS2030S',
 ]
 
-describe('Graph.initialize', () => {
+describe('Graph.suggestModulesFromOne', () => {
   describe('Suggests post-reqs of the given module', () => {
     it('Which the user is eligible for', async () => {
       const res = await container(db, () =>

--- a/packages/database/tests/graph/suggest/from-one.test.ts
+++ b/packages/database/tests/graph/suggest/from-one.test.ts
@@ -85,7 +85,7 @@ describe('Graph.initialize', () => {
       })
       t.suggestedModulesCodes = res.map((one) => one.moduleCode)
       const copy = [...t.suggestedModulesCodes]
-      expect(copy.sort()).toEqual(expected.sort())
+      expect(copy.sort()).toStrictEqual(expected.sort())
     })
 
     it('In our current desired priority', async () => {

--- a/packages/database/tests/module-condensed/fetch.test.ts
+++ b/packages/database/tests/module-condensed/fetch.test.ts
@@ -10,6 +10,8 @@ const db = getSource(dbName)
 beforeAll(() => setup(db))
 afterAll(() => teardown(db))
 
+const lowerBound = 6000
+
 test('moduleCondensed.fetch', async () => {
   await container(db, () =>
     ModuleCondensedRepository(db)
@@ -22,7 +24,7 @@ test('moduleCondensed.fetch', async () => {
          * expect all module codes to be unique
          */
         expect(s.size).toBe(moduleList.length)
-        expect(s.size).toBeGreaterThan(6000)
+        expect(s.size).toBeGreaterThan(lowerBound)
       })
   )
 })

--- a/packages/database/tests/module/pull.test.ts
+++ b/packages/database/tests/module/pull.test.ts
@@ -10,6 +10,8 @@ const db = getSource(dbName)
 beforeAll(() => setup(db))
 afterAll(() => teardown(db))
 
+const lowerBound = 6100
+
 jest.setTimeout(60000)
 test('pull all modules from NUSMods', async () => {
   expect.assertions(3)
@@ -20,7 +22,7 @@ test('pull all modules from NUSMods', async () => {
       .then((res) => {
         expect(res).toBeInstanceOf(Array)
         expect(res[0]).toBeInstanceOf(Module)
-        expect(res.length).toBeGreaterThan(6100)
+        expect(res.length).toBeGreaterThan(lowerBound)
       })
   )
 })

--- a/packages/database/tests/user/canTakeModule/add-module-codes.test.ts
+++ b/packages/database/tests/user/canTakeModule/add-module-codes.test.ts
@@ -1,7 +1,6 @@
 import { container, getSource } from '../../../src/data-source'
 import { User } from '../../../src/entity'
 import { UserRepository } from '../../../src/repository'
-import type * as InitProps from '../../../types/init-props'
 import Init from '../../init'
 import { setup, teardown } from '../../environment'
 import { oneUp } from '../../../src/utils'
@@ -10,19 +9,16 @@ const dbName = oneUp(__filename)
 const db = getSource(dbName)
 const t: Partial<{ user: User }> = {}
 
-beforeAll(() => setup(db))
+beforeAll(() =>
+  setup(db)
+    .then(() =>
+      UserRepository(db).initialize(Init.emptyUser),
+    )
+    .then((user) => {
+      t.user = user
+    })
+)
 afterAll(() => teardown(db))
-
-it('Saves an empty user', async () => {
-  const props: InitProps.User = Init.emptyUser
-  const res = await container(db, async () => {
-    await UserRepository(db).initialize(props)
-    return UserRepository(db).findOneByUsername(props.username)
-  })
-  expect(res).toBeDefined()
-  if (!res) return
-  t.user = res
-})
 
 it('Returns true for modules unlocked by the added modules', async () => {
   const addModuleCodes = ['MA2001']

--- a/packages/database/tests/user/canTakeModule/no-optional-params.test.ts
+++ b/packages/database/tests/user/canTakeModule/no-optional-params.test.ts
@@ -1,31 +1,32 @@
 import { container, getSource } from '../../../src/data-source'
 import { User } from '../../../src/entity'
 import { UserRepository } from '../../../src/repository'
+import type * as InitProps from '../../../types/init-props'
 import Init from '../../init'
 import { setup, teardown } from '../../environment'
 import { oneUp } from '../../../src/utils'
 
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
+
 const t: Partial<{ user: User }> = {}
 
-beforeAll(() => setup(db))
-afterAll(() => teardown(db))
+const userProps: InitProps.User = {
+  ...Init.emptyUser,
+  modulesDone: ['MA2001'],
+  modulesDoing: ['MA2219'],
+}
 
-it('Saves a user', async () => {
-  expect.assertions(1)
-  const props = Init.emptyUser
-  props.modulesDone.push('MA2001')
-  props.modulesDoing.push('MA2219')
-  await container(db, () =>
-    UserRepository(db)
-      .initialize(props)
-      .then((res) => {
-        expect(res).toBeInstanceOf(User)
-        t.user = res
-      })
-  )
-})
+beforeAll(() =>
+  setup(db)
+    .then(() =>
+      UserRepository(db).initialize(userProps),
+    )
+    .then((user) => {
+      t.user = user
+    })
+)
+afterAll(() => teardown(db))
 
 it('Correctly handles modules not taken before', async () => {
   expect.assertions(1)

--- a/packages/database/tests/user/eligibleModules/add-module-codes.test.ts
+++ b/packages/database/tests/user/eligibleModules/add-module-codes.test.ts
@@ -37,5 +37,5 @@ it('Adds only modules which have pre-reqs cleared', async () => {
   const eligibleModuleCodes = eligibleModules.map(
     (one: Module) => one.moduleCode
   )
-  expect(eligibleModuleCodes.sort()).toEqual(expected.sort())
+  expect(eligibleModuleCodes.sort()).toStrictEqual(expected.sort())
 })

--- a/packages/database/tests/user/eligibleModules/add-module-codes.test.ts
+++ b/packages/database/tests/user/eligibleModules/add-module-codes.test.ts
@@ -1,7 +1,6 @@
 import { container, getSource } from '../../../src/data-source'
 import { Module, User } from '../../../src/entity'
 import { UserRepository } from '../../../src/repository'
-import type * as InitProps from '../../../types/init-props'
 import Init from '../../init'
 import { setup, teardown } from '../../environment'
 import { oneUp } from '../../../src/utils'
@@ -10,19 +9,16 @@ const dbName = oneUp(__filename)
 const db = getSource(dbName)
 const t: Partial<{ user: User }> = {}
 
-beforeAll(() => setup(db))
+beforeAll(() =>
+  setup(db)
+    .then(() =>
+      UserRepository(db).initialize(Init.emptyUser),
+    )
+    .then((user) => {
+      t.user = user
+    })
+)
 afterAll(() => teardown(db))
-
-it('Saves an empty user', async () => {
-  const props: InitProps.User = Init.emptyUser
-  const res = await container(db, async () => {
-    await UserRepository(db).initialize(props)
-    return UserRepository(db).findOneByUsername(props.username)
-  })
-  expect(res).toBeDefined()
-  if (!res) return
-  t.user = res
-})
 
 it('Adds only modules which have pre-reqs cleared', async () => {
   const addModuleCodes = ['CS1101S']

--- a/packages/database/tests/user/eligibleModules/no-optional-params.ts
+++ b/packages/database/tests/user/eligibleModules/no-optional-params.ts
@@ -40,7 +40,7 @@ it('Adds only modules which have pre-reqs cleared', async () => {
          * Compare module codes
          */
         const eligibleModuleCodes = eligibleModules.map(Flatten.module)
-        expect(eligibleModuleCodes.sort()).toEqual(expected.sort())
+        expect(eligibleModuleCodes.sort()).toStrictEqual(expected.sort())
       })
   )
 })

--- a/packages/database/tests/user/getPostReqs/add-module-codes.test.ts
+++ b/packages/database/tests/user/getPostReqs/add-module-codes.test.ts
@@ -42,7 +42,7 @@ it('Gets all post-reqs', async () => {
   if (!mod) return
   // Compare module codes
   t.postReqsCodes = postReqs.map((one: Module) => one.moduleCode)
-  expect(t.postReqsCodes.sort()).toEqual(mod.fulfillRequirements.sort())
+  expect(t.postReqsCodes.sort()).toStrictEqual(mod.fulfillRequirements.sort())
 })
 
 it('Returns empty array for modules with empty string fulfillRequirements', async () => {

--- a/packages/database/tests/user/getPostReqs/add-module-codes.test.ts
+++ b/packages/database/tests/user/getPostReqs/add-module-codes.test.ts
@@ -1,7 +1,6 @@
 import { container, getSource } from '../../../src/data-source'
 import { Module, User } from '../../../src/entity'
 import { ModuleRepository, UserRepository } from '../../../src/repository'
-import type * as InitProps from '../../../types/init-props'
 import Init from '../../init'
 import { setup, teardown } from '../../environment'
 import { oneUp } from '../../../src/utils'
@@ -10,19 +9,16 @@ const dbName = oneUp(__filename)
 const db = getSource(dbName)
 const t: Partial<{ user: User; postReqsCodes: string[] }> = {}
 
-beforeAll(() => setup(db))
+beforeAll(() =>
+  setup(db)
+    .then(() =>
+      UserRepository(db).initialize(Init.emptyUser),
+    )
+    .then((user) => {
+      t.user = user
+    })
+)
 afterAll(() => teardown(db))
-
-it('Saves an empty user', async () => {
-  const props: InitProps.User = Init.emptyUser
-  const res = await container(db, async () => {
-    await UserRepository(db).initialize(props)
-    return UserRepository(db).findOneByUsername(props.username)
-  })
-  expect(res).toBeDefined()
-  if (!res) return
-  t.user = res
-})
 
 it('Gets all post-reqs', async () => {
   const addModuleCodes = ['MA2001']

--- a/packages/database/tests/user/getPostReqs/no-optional-params.test.ts
+++ b/packages/database/tests/user/getPostReqs/no-optional-params.test.ts
@@ -55,7 +55,7 @@ it('Gets all post-reqs', async () => {
           (one) => one !== 'MA2101'
         )
         // Compare module codes
-        expect(t.postReqsCodes.sort()).toEqual(expected.sort())
+        expect(t.postReqsCodes.sort()).toStrictEqual(expected.sort())
       })
   )
 })

--- a/packages/database/tests/user/getPostReqs/no-optional-params.test.ts
+++ b/packages/database/tests/user/getPostReqs/no-optional-params.test.ts
@@ -9,28 +9,27 @@ import { Flatten, oneUp } from '../../../src/utils'
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
 
-beforeAll(() => setup(db))
-afterAll(() => teardown(db))
-
 const t: Partial<{
   user: User
   postReqsCodes: string[]
 }> = {}
 
-it('Saves a user', async () => {
-  expect.assertions(1)
-  const props = Init.emptyUser
-  props.modulesDone.push('MA2001')
-  props.modulesDoing.push('MA2101')
-  await container(db, () =>
-    UserRepository(db)
-      .initialize(props)
-      .then((res) => {
-        expect(res).toBeInstanceOf(User)
-        t.user = res
-      })
-  )
-})
+const userProps: InitProps.User = {
+  ...Init.emptyUser,
+  modulesDone: ['MA2001'],
+  modulesDoing: ['MA2101'],
+}
+
+beforeAll(() =>
+  setup(db)
+    .then(() =>
+      UserRepository(db).initialize(userProps),
+    )
+    .then((user) => {
+      t.user = user
+    })
+)
+afterAll(() => teardown(db))
 
 it('Gets all post-reqs', async () => {
   // Get post reqs

--- a/packages/database/tests/user/getUnlockedModules.test.ts
+++ b/packages/database/tests/user/getUnlockedModules.test.ts
@@ -41,7 +41,7 @@ it('Correctly gets unlocked modules', async () => {
   const expected = ['CS2106', 'CS3210', 'CS3237']
   // Compare module codes
   const codes = modules.map((one: Module) => one.moduleCode)
-  expect(codes.sort()).toEqual(expected.sort())
+  expect(codes.sort()).toStrictEqual(expected.sort())
 })
 
 it('Does not modify User.modulesDone', async () => {

--- a/packages/database/tests/user/getUnlockedModules.test.ts
+++ b/packages/database/tests/user/getUnlockedModules.test.ts
@@ -9,26 +9,23 @@ import { oneUp } from '../../src/utils'
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
 
-beforeAll(() => setup(db))
-afterAll(() => teardown(db))
+const t: Partial<{ user: User }> = {}
 
-const t: Partial<{
-  user: User
-  props: InitProps.User
-}> = {
-  props: Init.emptyUser,
+const userProps: InitProps.User = {
+  ...Init.emptyUser,
+  modulesDone: ['CS1010']
 }
 
-it('Saves a user', async () => {
-  t.props.modulesDone.push('CS1010')
-  const res = await container(db, async () => {
-    await UserRepository(db).initialize(t.props)
-    return UserRepository(db).findOneByUsername(t.props.username)
-  })
-  expect(res).toBeDefined()
-  if (!res) return
-  t.user = res
-})
+beforeAll(() =>
+  setup(db)
+    .then(() =>
+      UserRepository(db).initialize(userProps),
+    )
+    .then((user) => {
+      t.user = user
+    })
+)
+afterAll(() => teardown(db))
 
 it('Correctly gets unlocked modules', async () => {
   // Get unlocked modules for CS2100

--- a/packages/database/tests/user/initialize.test.ts
+++ b/packages/database/tests/user/initialize.test.ts
@@ -1,0 +1,40 @@
+import { container, getSource } from '../../src/data-source'
+import { User } from '../../src/entity'
+import { UserRepository } from '../../src/repository'
+import Init from '../init'
+import { setup, teardown } from '../environment'
+import { oneUp } from '../../src/utils'
+
+const dbName = oneUp(__filename)
+const db = getSource(dbName)
+const t: Partial<{ user: User }> = {}
+
+beforeAll(() => setup(db))
+afterAll(() => teardown(db))
+
+const props = Init.user1
+
+describe('User.initialize', () => {
+  it('Saves an empty user', async () => {
+    expect.assertions(1)
+    await container(db, () =>
+      UserRepository(db)
+        .initialize(props)
+        .then((res) => {
+          expect(res).toBeInstanceOf(User)
+          t.user = res
+        })
+    )
+  })
+  it('Can find same user (without relations)', async () => {
+    expect.assertions(2)
+    await container(db, () =>
+      UserRepository(db)
+        .findOneByUsername(props.username)
+        .then((res) => {
+          expect(res).toBeInstanceOf(User)
+          expect(res).toStrictEqual(t.user)
+        })
+    )
+  })
+})

--- a/packages/database/types/repository.d.ts
+++ b/packages/database/types/repository.d.ts
@@ -26,6 +26,7 @@ interface BaseRepo<Entity, InitProps> extends Repository<Entity> {
 export interface GraphRepository extends BaseRepo<Graph, InitProps.Graph> {
   toggleModule(graph: Graph, moduleCode: string): Promise<void>
   loadRelations: LoadRelations<Graph>
+  findOneById(id: string): Promise<Graph>
   findOneByUserAndDegreeId(userId: string, degreeId: string): Promise<Graph>
   findManyByUserAndDegreeId(
     userId: string,


### PR DESCRIPTION
Clears all our tasks tagged as check

### Changes

- Write `GraphRepository.findOneById`

### Tests changes

- Add `Graph`, `GraphRepository` defined checks to tests
- `toEqual` -> `toStrictEqual` for sorted array checks in tests
- Remove repeated `User.initialize` tests, and instead have a test specifically for it
- `User.initialize` and `Degree.initialize` have find tests to confirm that the newly initialized entity is indeed in the DB
