### PR TITLE
feat(frontend): add saved graphs to user profile modal

### DIFF
--- a/apps/web/components/Views.tsx
+++ b/apps/web/components/Views.tsx
@@ -14,7 +14,7 @@ export function clickify(children: ReactChild) {
  */
 export function FullScreenOverlay(props: { children: ReactChild }) {
   return (
-    <div className="z-10 absolute left-0 top-0 h-screen w-screen pointer-events-none select-none">
+    <div className="z-10 fixed inset-0 pointer-events-none select-none">
       {clickify(props.children)}
     </div>
   )
@@ -28,7 +28,7 @@ export function HeaderOverlay(props: {
   children: ReactChild
 }) {
   return (
-    <div className="z-10 absolute left-0 top-0 h-16 w-screen py-2 pointer-events-none select-none">
+    <div className="z-10 fixed inset-0 h-16 w-screen py-2 pointer-events-none select-none">
       {clickify(props.children)}
     </div>
   )

--- a/apps/web/components/buttons/FloatingUserButton/SignedIn.tsx
+++ b/apps/web/components/buttons/FloatingUserButton/SignedIn.tsx
@@ -69,7 +69,7 @@ export default function SignedInCircle() {
           <Menu.Item key={`${menuItem.text}-${index}`}>
             <MenuLink href={menuItem.href || '#'} passHref>
               <a
-                className="hover:bg-blue-500 hover:text-white text-gray-900 flex w-full px-4 py-1.5 text-sm"
+                className="hover:bg-modtree-400/80 hover:text-white text-gray-900 flex w-full px-4 py-1.5 text-sm"
                 onClick={menuItem.callback}
               >
                 {menuItem.text}

--- a/apps/web/components/buttons/FloatingUserButton/SignedOut.tsx
+++ b/apps/web/components/buttons/FloatingUserButton/SignedOut.tsx
@@ -1,18 +1,11 @@
 import Link from 'next/link'
 
 export default function SignedOutRect() {
-  const padding = 'px-3'
-  const flex = 'flex flex-row'
-  const border = 'border border-gray-400 rounded-md'
-  const hover = 'hover:bg-gray-200'
-  const active = 'active:bg-gray-300'
   return (
-    <div
-      className={`cursor-pointer items-center h-10 ${flex} ${padding} ${border} ${hover} ${active}`}
-    >
-      <Link href="/api/auth/login" passHref>
-        <div className="text-gray-400">Sign in</div>
-      </Link>
+    <div className="inline-flex w-full justify-center rounded-md bg-black bg-opacity-20 px-4 py-2 text-sm font-medium text-white hover:bg-opacity-30 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75">
+       <Link href="/api/auth/login" passHref>
+         <a>Sign in</a>
+       </Link>
     </div>
   )
 }

--- a/apps/web/components/modals/UserProfile.tsx
+++ b/apps/web/components/modals/UserProfile.tsx
@@ -36,7 +36,7 @@ export default function UserProfileModal() {
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="fixed inset-0 bg-black bg-opacity-10" />
+          <div className="fixed inset-0 bg-gray-900 bg-opacity-10" />
         </Transition.Child>
         <div className="fixed inset-0 overflow-y-auto">
           <div className="flex min-h-full items-center justify-center p-4 text-center">

--- a/apps/web/components/modals/UserProfile.tsx
+++ b/apps/web/components/modals/UserProfile.tsx
@@ -16,11 +16,33 @@ export default function UserProfileModal() {
 
   const UserProfileContents = () => {
     return (
-      <div className="mt-2">
-        <p className="text-sm text-gray-500">
-          Saved graphs, degrees, modules done, modules doing.
-        </p>
+      <div className="mt-2 grid grid-cols-3">
+        <h3>Saved Graphs</h3>
+        <h3>Saved Degrees</h3>
+        <h3>Modules Done</h3>
       </div>
+    )
+  }
+
+  const Panel = () => {
+    return (
+      <Transition.Child
+        as={Fragment}
+        enter="ease-out duration-300"
+        enterFrom="opacity-0 scale-95"
+        enterTo="opacity-100 scale-100"
+        leave="ease-in duration-200"
+        leaveFrom="opacity-100 scale-100"
+        leaveTo="opacity-0 scale-95"
+      >
+        <div className="w-full max-w-4xl transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all">
+          <CloseButton close={closeModal} />
+          <h2 className="text-lg font-medium leading-6 text-gray-900">
+            User Profile
+          </h2>
+          <UserProfileContents />
+        </div>
+      </Transition.Child>
     )
   }
 
@@ -38,28 +60,9 @@ export default function UserProfileModal() {
         >
           <div className="fixed inset-0 bg-gray-900 bg-opacity-10" />
         </Transition.Child>
-        <div className="fixed inset-0 overflow-y-auto">
+        <div className="fixed inset-0 overflow-y-hidden">
           <div className="flex min-h-full items-center justify-center p-4 text-center">
-            <Transition.Child
-              as={Fragment}
-              enter="ease-out duration-300"
-              enterFrom="opacity-0 scale-95"
-              enterTo="opacity-100 scale-100"
-              leave="ease-in duration-200"
-              leaveFrom="opacity-100 scale-100"
-              leaveTo="opacity-0 scale-95"
-            >
-              <Dialog.Panel className="w-full max-w-4xl transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all">
-                <Dialog.Title
-                  as="h2"
-                  className="text-lg font-medium leading-6 text-gray-900"
-                >
-                  <CloseButton close={closeModal} />
-                  User Profile
-                  <UserProfileContents />
-                </Dialog.Title>
-              </Dialog.Panel>
-            </Transition.Child>
+            <Panel />
           </div>
         </div>
       </Dialog>

--- a/apps/web/components/modals/UserProfile.tsx
+++ b/apps/web/components/modals/UserProfile.tsx
@@ -2,7 +2,7 @@ import { Dialog, Transition } from '@headlessui/react'
 import { Fragment } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { ModalState, hideUserProfile } from '@/store/modal'
-import { XIcon } from '@heroicons/react/outline'
+import { CloseButton } from '@/ui/buttons'
 
 export default function UserProfileModal() {
   const showUserProfile = useSelector<ModalState, boolean>(
@@ -12,17 +12,6 @@ export default function UserProfileModal() {
 
   function closeModal() {
     dispatch(hideUserProfile())
-  }
-
-  const CloseButton = () => {
-    const hover = ' hover:bg-gray-200 active:bg-gray-300 cursor-pointer'
-    const center = ' flex flex-row justify-center items-center'
-    const className = 'w-6 h-6 absolute right-6 rounded-md' + hover + center
-    return (
-      <div className={className} onClick={closeModal}>
-        <XIcon className="text-gray-600 h-5 w-5" />
-      </div>
-    )
   }
 
   const UserProfileContents = () => {
@@ -65,7 +54,7 @@ export default function UserProfileModal() {
                   as="h2"
                   className="text-lg font-medium leading-6 text-gray-900"
                 >
-                  <CloseButton />
+                  <CloseButton close={closeModal} />
                   User Profile
                   <UserProfileContents />
                 </Dialog.Title>

--- a/apps/web/components/modals/UserProfile/SavedGraphs.tsx
+++ b/apps/web/components/modals/UserProfile/SavedGraphs.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react'
+import { RadioGroup } from '@headlessui/react'
+
+const graphs = [
+  {
+    name: 'The Game Plan',
+    degree: 'Computer Science',
+    count: '6 modules',
+  },
+  {
+    name: 'Life on hard-mode',
+    degree: 'Mathematics',
+    count: '8 modules',
+  },
+  {
+    name: 'Chase your dreams',
+    degree: 'Music',
+    count: '9 modules',
+  },
+]
+
+export default function SavedGraphs() {
+  const [selected, setSelected] = useState(graphs[0])
+
+  return (
+    <div className="w-full">
+      <div className="mx-auto w-full max-w-md">
+        <RadioGroup value={selected} onChange={setSelected}>
+          <RadioGroup.Label className="sr-only">Server size</RadioGroup.Label>
+          <div className="space-y-2">
+            {graphs.map((graph) => (
+              <RadioGroup.Option
+                key={graph.name}
+                value={graph}
+                className={({ checked }) =>
+                  `${checked ? 'bg-modtree-300 text-white' : 'bg-white'}
+                    relative flex cursor-pointer rounded-lg px-5 py-4 shadow-md focus:outline-none`
+                }
+              >
+                {({ checked }) => (
+                  <>
+                    <div className="flex w-full items-center justify-between">
+                      <div className="flex items-center">
+                        <div className="text-sm">
+                          <RadioGroup.Label
+                            as="p"
+                            className={`font-medium  ${
+                              checked ? 'text-white' : 'text-gray-900'
+                            }`}
+                          >
+                            {graph.name}
+                          </RadioGroup.Label>
+                          <RadioGroup.Description
+                            as="span"
+                            className={`inline ${
+                              checked ? 'text-modtree-50' : 'text-gray-500'
+                            }`}
+                          >
+                            <span>
+                              {graph.degree}
+                            </span>{' '}
+                            <span aria-hidden="true">&middot;</span>{' '}
+                            <span>{graph.count}</span>
+                          </RadioGroup.Description>
+                        </div>
+                      </div>
+                      {checked && (
+                        <div className="shrink-0 text-white">
+                          <CheckIcon className="h-6 w-6" />
+                        </div>
+                      )}
+                    </div>
+                  </>
+                )}
+              </RadioGroup.Option>
+            ))}
+          </div>
+        </RadioGroup>
+      </div>
+    </div>
+  )
+}
+
+function CheckIcon(props) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" {...props}>
+      <circle cx={12} cy={12} r={12} fill="#fff" opacity="0.2" />
+      <path
+        d="M7 13l3 3 7-7"
+        stroke="#fff"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}

--- a/apps/web/components/modals/UserProfile/index.tsx
+++ b/apps/web/components/modals/UserProfile/index.tsx
@@ -19,7 +19,7 @@ export default function UserProfileModal() {
     return (
       <div className="mt-2 grid grid-cols-3 space-x-6">
         <div>
-          <h3 className='mb-4'>Saved Graphs</h3>
+          <h3 className="mb-4">Saved Graphs</h3>
           <SavedGraphs />
         </div>
         <h3>Saved Degrees</h3>
@@ -39,13 +39,13 @@ export default function UserProfileModal() {
         leaveFrom="opacity-100 scale-100"
         leaveTo="opacity-0 scale-95"
       >
-        <div className="w-full max-w-4xl transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all">
+        <Dialog.Panel className="w-full max-w-4xl transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all">
           <CloseButton close={closeModal} />
           <h2 className="text-lg font-medium leading-6 text-gray-900 mb-4">
             User Profile
           </h2>
           <UserProfileContents />
-        </div>
+        </Dialog.Panel>
       </Transition.Child>
     )
   }

--- a/apps/web/components/modals/UserProfile/index.tsx
+++ b/apps/web/components/modals/UserProfile/index.tsx
@@ -3,6 +3,7 @@ import { Fragment } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { ModalState, hideUserProfile } from '@/store/modal'
 import { CloseButton } from '@/ui/buttons'
+import SavedGraphs from './SavedGraphs'
 
 export default function UserProfileModal() {
   const showUserProfile = useSelector<ModalState, boolean>(
@@ -16,8 +17,11 @@ export default function UserProfileModal() {
 
   const UserProfileContents = () => {
     return (
-      <div className="mt-2 grid grid-cols-3">
-        <h3>Saved Graphs</h3>
+      <div className="mt-2 grid grid-cols-3 space-x-6">
+        <div>
+          <h3 className='mb-4'>Saved Graphs</h3>
+          <SavedGraphs />
+        </div>
         <h3>Saved Degrees</h3>
         <h3>Modules Done</h3>
       </div>
@@ -37,7 +41,7 @@ export default function UserProfileModal() {
       >
         <div className="w-full max-w-4xl transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all">
           <CloseButton close={closeModal} />
-          <h2 className="text-lg font-medium leading-6 text-gray-900">
+          <h2 className="text-lg font-medium leading-6 text-gray-900 mb-4">
             User Profile
           </h2>
           <UserProfileContents />

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -4,6 +4,15 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer components {
+  .modtree-gradient {
+    @apply bg-gradient-to-r from-pink-400 to-orange-400;
+  }
+  .modtree-solid {
+    background-color: #ff4000;
+  }
+}
+
 html {
   @apply bg-gray-50 select-none;
 }

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -3,6 +3,7 @@ const { fontFamily } = require('tailwindcss/defaultTheme')
 module.exports = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx}',
+    './ui/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -11,6 +11,20 @@ module.exports = {
       fontFamily: {
         sans: ['Inter', ...fontFamily.sans],
       },
+      colors: {
+        modtree: {
+          50: '#FFCAB8',
+          100: '#FFBAA3',
+          200: '#FF9C7A',
+          300: '#FF7D52',
+          400: '#FF5F29',
+          500: '#FF4000',
+          600: '#C73200',
+          700: '#8F2400',
+          800: '#571600',
+          900: '#1F0800',
+        },
+      },
     },
   },
   plugins: [

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -11,6 +11,7 @@
       "@modtree/types": ["../../libs/types/src/index.ts"],
       "@/components/*": ["components/*"],
       "@/store/*": ["store/*"],
+      "@/ui/*": ["ui/*"],
       "@/styles/*": ["styles/*"],
       "@/utils/*": ["utils/*"],
       "@/flow/*": ["flow/*"]

--- a/apps/web/ui/buttons.tsx
+++ b/apps/web/ui/buttons.tsx
@@ -1,0 +1,12 @@
+import { XIcon } from '@heroicons/react/outline'
+
+export const CloseButton = (props: { close: () => void }) => {
+  const hover = ' hover:bg-gray-200 active:bg-gray-300 cursor-pointer'
+  const center = ' flex flex-row justify-center items-center'
+  const className = 'w-6 h-6 absolute right-6 rounded-md' + hover + center
+  return (
+    <div className={className} onClick={props.close}>
+      <XIcon className="text-gray-600 h-5 w-5" />
+    </div>
+  )
+}


### PR DESCRIPTION
### Summary of changes

- mostly a proof-of-concept for other neighboring fields too

### Testing

- `yarn serve` -> localhost:3000 -> Sign in -> User button -> Your Profile. It should show a fancy list of saved graphs.
