### PR TITLE
test: jest timeouts

### DIFF
--- a/libs/repo-graph/jest.config.ts
+++ b/libs/repo-graph/jest.config.ts
@@ -13,4 +13,5 @@ export default {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../coverage/libs/repo-graph',
+  testTimeout: 15000,
 }

--- a/libs/repo-graph/test/suggest/from-all.test.ts
+++ b/libs/repo-graph/test/suggest/from-all.test.ts
@@ -82,8 +82,6 @@ const expected = [
   'CS2040S',
 ]
 
-jest.setTimeout(15000)
-
 describe('Graph.suggestModules (from many)', () => {
   it('Suggests post-reqs of the given module which the user is eligible for', async () => {
     const selectedModules = userProps.modulesDone

--- a/libs/repo-graph/test/suggest/from-one.test.ts
+++ b/libs/repo-graph/test/suggest/from-one.test.ts
@@ -31,8 +31,6 @@ const userProps: InitProps['User'] = {
   modulesDoing: ['IT2002'],
 }
 
-jest.setTimeout(15000)
-
 beforeAll(() =>
   setup(db)
     .then(() => {

--- a/libs/repo-module/jest.config.ts
+++ b/libs/repo-module/jest.config.ts
@@ -13,4 +13,5 @@ export default {
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../coverage/libs/repo-module',
   testPathIgnorePatterns: ['./test/pull/*'],
+  testTimeout: 15000,
 }

--- a/libs/repo-module/test/module/canTakeModule.test.ts
+++ b/libs/repo-module/test/module/canTakeModule.test.ts
@@ -16,8 +16,6 @@ afterAll(() => teardown(db))
 const modulesDone = ['MA2001']
 const modulesDoing = ['MA2219']
 
-jest.setTimeout(10000)
-
 it('Correctly handles fresh modules', async () => {
   expect.assertions(1)
   const modulesTested = ['MA2101', 'MA1100', 'CS2040S', 'CS1010S']

--- a/libs/repo-module/test/module/getSuggestedModules/from-many.test.ts
+++ b/libs/repo-module/test/module/getSuggestedModules/from-many.test.ts
@@ -23,8 +23,6 @@ const requiredModules = [
 const modulesDone = ['CS1010', 'CG2111A', 'CS1231']
 const modulesDoing = ['IT2002']
 
-jest.setTimeout(15000)
-
 beforeAll(() =>
   setup(db).then(() => {
     Repo.Module = new ModuleRepository(db)

--- a/libs/repo-module/test/module/getSuggestedModules/from-one.test.ts
+++ b/libs/repo-module/test/module/getSuggestedModules/from-one.test.ts
@@ -20,8 +20,6 @@ const requiredModules = [
 const modulesDone = ['CS1010', 'CG2111A']
 const modulesDoing = ['IT2002']
 
-jest.setTimeout(15000)
-
 beforeAll(() =>
   setup(db).then(() => {
     Repo.Module = new ModuleRepository(db)

--- a/libs/repo-module/test/pull/module-condensed.test.ts
+++ b/libs/repo-module/test/pull/module-condensed.test.ts
@@ -16,7 +16,6 @@ beforeAll(() =>
 )
 afterAll(() => teardown(db))
 
-jest.setTimeout(10000)
 test('moduleCondensed.pull', async () => {
   await container(db, () => Repo.ModuleCondensed!.deleteAll())
   const pullOnEmpty = await container(db, () => Repo.ModuleCondensed!.pull())


### PR DESCRIPTION
### Summary of changes

Sets default jest test timeout to 15s for `repo-graph` and `repo-user`

- so that if we have somewhat long tests, we don't have to do `jest.setTimeout(xxxx)`
- 15s is chosen, because most of our setTimeouts are <=15s (10s or 15s)

Not very sure if this is a useful change.

### Testing

Initialize `libs/repo-graph/test/long.test.ts` as follows. The test should fail due to exceeding the default timeout of 15000ms.

```
test('exceeds threshold', async () => {
  return new Promise((resolve) => {
    setTimeout(() => resolve(1), 16000);
  });
})
```

### Notes

Interestingly, jest currently does not catch infinite loops as per [this issue](https://github.com/facebook/jest/issues/10538), so you can't test with an infinite loop.