### PR TITLE
feat: User.setModuleStatus

### DIFF
--- a/libs/repo-user/test/setModuleStatus.test.ts
+++ b/libs/repo-user/test/setModuleStatus.test.ts
@@ -102,4 +102,16 @@ describe('User.setModuleStatus', () => {
       expectUserModules(['MA2001'], ['MA2219'])
     })
   })
+
+  it('Throws error if invalid module code is passed in', async () => {
+    await container(db, () =>
+      expect(() =>
+        Repo.User!.setModuleStatus(
+          t.user!,
+          init.invalidModuleCode,
+          ModuleStatus.DONE
+        )
+      ).rejects.toThrow(Error)
+    )
+  })
 })

--- a/libs/repo-user/test/setModuleStatus.test.ts
+++ b/libs/repo-user/test/setModuleStatus.test.ts
@@ -1,0 +1,105 @@
+import { setup, teardown, Repo, t, init } from '@modtree/test-env'
+import { flatten, oneUp } from '@modtree/utils'
+import { container, getSource } from '@modtree/typeorm-config'
+import { UserRepository } from '../src'
+import { ModuleStatus } from '@modtree/types'
+
+const dbName = oneUp(__filename)
+const db = getSource(dbName)
+
+beforeAll(() =>
+  setup(db)
+    .then(() => {
+      Repo.User = new UserRepository(db)
+      return Repo.User!.initialize(init.user1)
+    })
+    .then((user) => {
+      t.user = user
+    })
+)
+afterAll(() => teardown(db))
+
+/**
+ * @param {string[]} modulesDoneCodes
+ * @param {string[]} modulesDoingCodes
+ */
+function expectUserModules(
+  modulesDoneCodes: string[],
+  modulesDoingCodes: string[]
+) {
+  const modulesDone = t.user!.modulesDone.map(flatten.module)
+  const modulesDoing = t.user!.modulesDoing.map(flatten.module)
+  expect(modulesDone.sort()).toStrictEqual(modulesDoneCodes.sort())
+  expect(modulesDoing.sort()).toStrictEqual(modulesDoingCodes.sort())
+}
+
+/**
+ * init.user1 has
+ * modulesDone = ['MA2001']
+ * modulesDoing = ['MA2219']
+ *
+ * This test covers all 6 cases of switching state between
+ * done, doing, not taken.
+ */
+
+describe('User.setModuleStatus', () => {
+  it('done -> doing -> done', async () => {
+    expect.assertions(4)
+    await container(db, async () => {
+      // done -> doing
+      t.user = await Repo.User!.setModuleStatus(
+        t.user!,
+        'MA2001',
+        ModuleStatus.DOING
+      )
+      expectUserModules([], ['MA2001', 'MA2219'])
+      // doing -> done
+      t.user = await Repo.User!.setModuleStatus(
+        t.user!,
+        'MA2001',
+        ModuleStatus.DONE
+      )
+      expectUserModules(['MA2001'], ['MA2219'])
+    })
+  })
+
+  it('done -> not taken -> done', async () => {
+    expect.assertions(4)
+    await container(db, async () => {
+      // done -> not taken
+      t.user = await Repo.User!.setModuleStatus(
+        t.user!,
+        'MA2001',
+        ModuleStatus.NOT_TAKEN
+      )
+      expectUserModules([], ['MA2219'])
+      // not taken -> done
+      t.user = await Repo.User!.setModuleStatus(
+        t.user!,
+        'MA2001',
+        ModuleStatus.DONE
+      )
+      expectUserModules(['MA2001'], ['MA2219'])
+    })
+  })
+
+  it('doing -> not taken -> doing', async () => {
+    expect.assertions(4)
+    await container(db, async () => {
+      // doing -> not taken
+      t.user = await Repo.User!.setModuleStatus(
+        t.user!,
+        'MA2219',
+        ModuleStatus.NOT_TAKEN
+      )
+      expectUserModules(['MA2001'], [])
+      // not taken -> doing
+      t.user = await Repo.User!.setModuleStatus(
+        t.user!,
+        'MA2219',
+        ModuleStatus.DOING
+      )
+      expectUserModules(['MA2001'], ['MA2219'])
+    })
+  })
+})

--- a/libs/typeorm-config/src/data-source.ts
+++ b/libs/typeorm-config/src/data-source.ts
@@ -14,7 +14,6 @@ export function getSource(database: string): DataSource {
     ...config,
     database,
   }
-  console.log('Data source options:', dataSourceOptions)
   return new DataSource(dataSourceOptions)
 }
 

--- a/libs/types/src/repository.ts
+++ b/libs/types/src/repository.ts
@@ -10,6 +10,12 @@ import {
 
 export type FindOneById<T> = (query: string) => Promise<T>
 
+export enum ModuleStatus {
+  NOT_TAKEN = 0,
+  DONE = 1,
+  DOING = 2,
+}
+
 /**
  * BaseRepository, but for now only in types
  * it is a interface that will be extended to form the final Repositories of modtree
@@ -53,6 +59,11 @@ export interface IUserRepository extends EUser {
   addDegree(user: IUser, degreeId: string): Promise<IUser>
   findDegree(user: IUser, degreeId: string): Promise<IDegree>
   removeDegree(user: IUser, degreeId: string): Promise<IUser>
+  setModuleStatus(
+    user: IUser,
+    moduleCode: string,
+    status: ModuleStatus
+  ): Promise<IUser>
 }
 
 export interface IDegreeRepository extends EDegree {


### PR DESCRIPTION
### Summary of changes

Creates `User.setModuleStatus`, to set a module as done, doing, or not taken. In preparation for the controller, which will be used in our right click menu

### Testing

User tests should pass
