### PR TITLE
feat: postman from v0.1.0 + some improvements

### DIFF
--- a/libs/postman/.gitignore
+++ b/libs/postman/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.DS_Store

--- a/libs/postman/degree/create.ts
+++ b/libs/postman/degree/create.ts
@@ -1,0 +1,33 @@
+import { ParseArgs, postman } from '../postman'
+
+const degrees = [
+  {
+    moduleCodes: [
+      'CS1101S',
+      'CS1231S',
+      'CS2030S',
+      'CS2040S',
+      'CS2100',
+      'CS2103T',
+      'CS2106',
+      'CS2109S',
+      'CS3230',
+      'MA1521',
+      'MA2001',
+      'ST2334',
+      'CP4101',
+    ],
+    title: 'Computer_Science',
+  },
+]
+
+function help() {
+  console.log('Please supply a username as an argument:')
+  console.log(degrees.map((d) => d.title))
+  process.exit()
+}
+
+const args = new ParseArgs(__filename, help)
+const degree = degrees.find((u) => u.title === args.last)
+if (!degree) help()
+postman.post('degree/create', degree)

--- a/libs/postman/degree/delete.ts
+++ b/libs/postman/degree/delete.ts
@@ -1,0 +1,7 @@
+import { ParseArgs, postman } from '../postman'
+
+const args = new ParseArgs(__filename, () => {
+  console.log('Please supply an id as an argument:')
+})
+
+postman.delete(`degree/delete/${args.last}`)

--- a/libs/postman/degree/list.ts
+++ b/libs/postman/degree/list.ts
@@ -1,0 +1,9 @@
+import { postman } from '../postman'
+
+postman.get('degree/list').then((res) => {
+  const pretty = res.map((u: any) => ({
+    id: u.id,
+    title: u.title,
+  }))
+  console.log(pretty)
+})

--- a/libs/postman/graph/create.ts
+++ b/libs/postman/graph/create.ts
@@ -1,0 +1,55 @@
+// const graph = {
+//   userId: '7e0000d8-48a9-41e0-8163-8466f6381d46',
+//   degreeId: '456ffd23-1d48-48da-beec-532ce058f902',
+//   modulesPlacedCodes: [],
+//   modulesHiddenCodes: [],
+//   pullAll: true,
+// }
+//
+// postman.post('graph/create', graph)
+//
+import { ParseArgs, postman } from '../postman'
+
+const degrees = [
+  {
+    moduleCodes: [
+      'CS1101S',
+      'CS1231S',
+      'CS2030S',
+      'CS2040S',
+      'CS2100',
+      'CS2103T',
+      'CS2106',
+      'CS2109S',
+      'CS3230',
+      'MA1521',
+      'MA2001',
+      'ST2334',
+      'CP4101',
+    ],
+    title: 'Computer_Science',
+  },
+]
+
+function help() {
+  console.log('\nUSAGE:\n')
+  console.log('yarn graph:create <user id> <degree id>\n')
+  Promise.all([postman.get('user/list'), postman.get('degree/list')]).then(
+    ([users, degrees]) => {
+      const userSummary = users.map((u: any) => ({ id: u.id, u: u.username }))
+      const degreeSummary = degrees.map((d: any) => ({ id: d.id, t: d.title }))
+      console.log('users:', userSummary)
+      console.log('degrees:', degreeSummary)
+    }
+  )
+}
+
+const args = new ParseArgs(__filename, help)
+const [userId, degreeId] = args.postArgs
+postman.post('graph/create', {
+  userId,
+  degreeId,
+  modulesPlacedCodes: [],
+  modulesHiddenCodes: [],
+  pullAll: true,
+})

--- a/libs/postman/graph/delete.ts
+++ b/libs/postman/graph/delete.ts
@@ -1,0 +1,7 @@
+import { ParseArgs, postman } from '../postman'
+
+const args = new ParseArgs(__filename, () => {
+  console.log('Please supply an id as an argument:')
+})
+
+postman.delete(`graph/delete/${args.last}`).then(console.log)

--- a/libs/postman/graph/list.ts
+++ b/libs/postman/graph/list.ts
@@ -1,0 +1,10 @@
+import { postman } from '../postman'
+
+postman.get('graph/list').then((res) => {
+  const pretty = res.map((g: any) => ({
+    id: g.id,
+    user: g.user,
+    degree: g.degree,
+  }))
+  console.log(pretty)
+})

--- a/libs/postman/package.json
+++ b/libs/postman/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@modtree/postman",
+  "version": "0.0.1",
+  "main": "index.js",
+  "license": "MIT",
+  "scripts": {
+    "ts": "tsc && node",
+    "user:get": "yarn ts ./dist/user/get.js",
+    "user:get-full": "yarn ts ./dist/user/get-full.js",
+    "user:list": "yarn ts ./dist/user/list.js",
+    "user:create": "yarn ts ./dist/user/create.js",
+    "user:delete": "yarn ts ./dist/user/delete.js",
+    "user:insert-degree": "yarn ts ./dist/user/insert-degree.js",
+    "degree:create": "yarn ts ./dist/degree/create.js",
+    "degree:list": "yarn ts ./dist/degree/list.js",
+    "degree:delete": "yarn ts ./dist/degree/delete.js",
+    "graph:create": "yarn ts ./dist/graph/create.js",
+    "graph:list": "yarn ts ./dist/graph/list.js",
+    "graph:delete": "yarn ts ./dist/graph/delete.js",
+    "ug": "yarn user:get",
+    "ugf": "yarn user:get-full",
+    "uc": "yarn user:create",
+    "ul": "yarn user:list",
+    "ud": "yarn user:delete",
+    "uid": "yarn user:insert-degree",
+    "dc": "yarn degree:create",
+    "dl": "yarn degree:list",
+    "dd": "yarn degree:delete",
+    "gc": "yarn graph:create",
+    "gl": "yarn graph:list",
+    "gd": "yarn graph:delete"
+  }
+}

--- a/libs/postman/postman.config.json
+++ b/libs/postman/postman.config.json
@@ -1,0 +1,3 @@
+{
+  "url": "http://localhost:8080/"
+}

--- a/libs/postman/postman.ts
+++ b/libs/postman/postman.ts
@@ -1,0 +1,72 @@
+import axios, { AxiosError, AxiosResponse } from 'axios'
+import boxen from 'boxen'
+import fs from 'fs'
+
+const box = (t: string, color: string) =>
+  boxen(t, {
+    borderColor: color,
+    padding: {
+      right: 2,
+      left: 2,
+      top: 0,
+      bottom: 0,
+    },
+  })
+
+const print = {
+  status: () => console.log(box('STATUS', 'green')),
+  data: () => console.log(box('DATA', 'green')),
+}
+
+const log = {
+  response: (res: AxiosResponse<any, any>) => {
+    // print.status()
+    // console.log(res.status)
+    // print.data()
+    // console.log(res.data)
+    return res.data
+  },
+  error: (err: AxiosError) => {
+    const { status, data } = err.response
+    // console.log(err.code)
+    // print.status()
+    // console.log('status:', status)
+    // print.data()
+    // console.log('data:', data)
+  },
+}
+
+async function verbosify(apiCall: () => Promise<any>): Promise<any> {
+  return apiCall().then(log.response).catch(log.error)
+}
+
+export class postman {
+  static url = JSON.parse(fs.readFileSync('postman.config.json').toString()).url
+  static get(endpoint: string) {
+    return verbosify(() => axios.get(postman.url + endpoint))
+  }
+  static post(endpoint: string, params?: any) {
+    return verbosify(() => axios.post(postman.url + endpoint, params))
+  }
+  static delete(endpoint: string, params?: any) {
+    return verbosify(() => axios.delete(postman.url + endpoint, params))
+  }
+}
+
+export class ParseArgs {
+  args: string[]
+  postArgs: string[]
+  last: string
+  constructor(filename: string, callback: () => void) {
+    this.args = process.argv
+    this.last = this.args[this.args.length - 1]
+    if (this.last === filename) {
+      console.log('GONNA CALL BACK')
+      callback()
+    }
+    this.postArgs = this.args.slice(
+      this.args.indexOf(filename) + 1,
+      this.args.length
+    )
+  }
+}

--- a/libs/postman/tsconfig.json
+++ b/libs/postman/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "rootDir": ".",
+    "lib": ["es5", "es6", "dom"],
+    "skipLibCheck": true,
+    "target": "es5",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "outDir": "./dist",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "sourceMap": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/libs/postman/user/create.ts
+++ b/libs/postman/user/create.ts
@@ -1,0 +1,65 @@
+import { ParseArgs, postman } from '../postman'
+
+const users = [
+  {
+    displayName: 'Nguyen Vu Khang',
+    username: 'khang',
+    email: 'khang@modtree.com',
+    modulesDone: [
+      'MA2001,',
+      'MA1100,',
+      'HSH1000,',
+      'HSA1000,',
+      'GEA1000',
+      'IS1103',
+      'CS1010S',
+      'DTK1234',
+      'HS1401S',
+      'HSI1000',
+      'HSS1000',
+      'MA2002',
+      'MA2219',
+      'PC1432',
+    ],
+    modulesDoing: [],
+    matriculationYear: 2021,
+    graduationYear: 2024,
+    graduationSemester: 2,
+  },
+  {
+    displayName: 'Tan Wei Seng',
+    username: 'weiseng',
+    email: 'weiseng@modtree.com',
+    modulesDone: [
+      'MA1521',
+      'MA2001',
+      'CS1231S',
+      'CS2100',
+      'CS2030S',
+      'IS1103',
+      'CS2040S',
+      'CS2106',
+      'MA2101',
+      'PC1201',
+      'ES2660',
+      'ST1131',
+      'EL1101E',
+      'LAJ2203',
+    ],
+    modulesDoing: [],
+    matriculationYear: 2021,
+    graduationYear: 2024,
+    graduationSemester: 2,
+  },
+]
+
+function help() {
+  console.log('Please supply a username as an argument:')
+  console.log(users.map((u) => u.username))
+  process.exit()
+}
+
+const args = new ParseArgs(__filename, help)
+const user = users.find((u) => u.username === args.last)
+if (!user) help()
+postman.post('user/create', user)

--- a/libs/postman/user/delete.ts
+++ b/libs/postman/user/delete.ts
@@ -1,0 +1,7 @@
+import { ParseArgs, postman } from '../postman'
+
+const args = new ParseArgs(__filename, () => {
+  console.log('Please supply an id as an argument:')
+})
+
+postman.delete(`user/delete/${args.last}`)

--- a/libs/postman/user/get-full.ts
+++ b/libs/postman/user/get-full.ts
@@ -1,5 +1,5 @@
 import { postman } from '../postman'
 
-const id = '6e0000d8-48a9-41e0-8163-8466f6381d46'
+const id = '9f0b22dd-e076-4677-9968-5ac4c49155d1'
 
-postman.get(`user/get-full/${id}`)
+postman.get(`user/get-full/${id}`).then(console.log)

--- a/libs/postman/user/get-full.ts
+++ b/libs/postman/user/get-full.ts
@@ -1,0 +1,5 @@
+import { postman } from '../postman'
+
+const id = '6e0000d8-48a9-41e0-8163-8466f6381d46'
+
+postman.get(`user/get-full/${id}`)

--- a/libs/postman/user/get.ts
+++ b/libs/postman/user/get.ts
@@ -1,0 +1,5 @@
+import { postman } from '../postman'
+
+const id = '2b931db3-bb49-4c71-b6dd-bb89e39d9308'
+
+postman.get(`user/get/${id}`)

--- a/libs/postman/user/get.ts
+++ b/libs/postman/user/get.ts
@@ -1,5 +1,5 @@
 import { postman } from '../postman'
 
-const id = '2b931db3-bb49-4c71-b6dd-bb89e39d9308'
+const id = '9f0b22dd-e076-4677-9968-5ac4c49155d1'
 
-postman.get(`user/get/${id}`)
+postman.get(`user/get/${id}`).then(console.log)

--- a/libs/postman/user/insert-degree.ts
+++ b/libs/postman/user/insert-degree.ts
@@ -1,0 +1,10 @@
+import { postman } from '../postman'
+
+const user = {
+  id: '6e0000d8-48a9-41e0-8163-8466f6381d46',
+  savedDegrees: ['456ffd23-1d48-48da-beec-532ce058f902'],
+}
+
+postman.post(`user/insert-degree/${user.id}`, {
+  degreeIds: user.savedDegrees,
+})

--- a/libs/postman/user/insert-degree.ts
+++ b/libs/postman/user/insert-degree.ts
@@ -5,6 +5,8 @@ const user = {
   savedDegrees: ['456ffd23-1d48-48da-beec-532ce058f902'],
 }
 
-postman.post(`user/insert-degree/${user.id}`, {
-  degreeIds: user.savedDegrees,
-})
+postman
+  .post(`user/insert-degree/${user.id}`, {
+    degreeIds: user.savedDegrees,
+  })
+  .then(console.log)

--- a/libs/postman/user/list.ts
+++ b/libs/postman/user/list.ts
@@ -1,0 +1,9 @@
+import { postman } from '../postman'
+
+postman.get('user/list').then((res) => {
+  const pretty = res.map((u: any) => ({
+    id: u.id,
+    user: u.username,
+  }))
+  console.log(pretty)
+})


### PR DESCRIPTION
### Summary of changes

- postman but now it also takes cli arguments so we don't have to edit the files each time ids change.

### General usage
```
yarn <entity>:<action> <positional args>
```

#### Example
Reads ids whenever it's clearly necessary (such as when creating a graph, it needs user id and degree id).
```
yarn user:delete dcc3b6ff-669a-475a-819f-d5e5a3e68d5c
```

Other commands don't need ids
```
yarn degree:list
```

As usual, there are aliases for everything.
`yarn graph:create` is aliases to `yarn gc`

