### PR TITLE
feat(frontend): add a debug modal

### DIFF
--- a/apps/web/components/buttons/FloatingUserButton/MenuLink.tsx
+++ b/apps/web/components/buttons/FloatingUserButton/MenuLink.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link'
+import { ForwardedRef, forwardRef } from 'react'
+
+function getMenuLink() {
+  const MenuLink = forwardRef(
+    (
+      props: {
+        href: string
+        children: string
+        className: string
+        onClick?: () => void
+      },
+      ref: ForwardedRef<HTMLAnchorElement>
+    ) => {
+      const { href, children, className, onClick } = props
+      return (
+        <Link href={href} passHref>
+          <a className={className} onClick={onClick} ref={ref}>
+            {children}
+          </a>
+        </Link>
+      )
+    }
+  )
+  MenuLink.displayName = 'MenuLink'
+  return MenuLink
+}
+
+export const MenuLink = getMenuLink()

--- a/apps/web/components/buttons/FloatingUserButton/SignedIn.tsx
+++ b/apps/web/components/buttons/FloatingUserButton/SignedIn.tsx
@@ -1,13 +1,10 @@
 import { IoPerson } from 'react-icons/io5'
 import { useUser } from '@/utils/auth0'
 import { Menu } from '@headlessui/react'
-import axios from 'axios'
-import { createRef, useEffect } from 'react'
+import { createRef } from 'react'
 import DropdownMenu, { MenuLink } from './DropdownMenu'
-import { useDispatch, useSelector } from 'react-redux'
+import { useDispatch } from 'react-redux'
 import { showUserProfile } from '@/store/modal'
-import { setBaseUser, UserState } from '@/store/base'
-import { ModtreeApiResponse } from '@modtree/types'
 
 function UserCircleArea() {
   const bg = 'bg-gradient-to-r from-pink-400 to-orange-400'
@@ -24,25 +21,7 @@ function UserCircleArea() {
 export default function SignedInCircle() {
   const { user } = useUser()
   const dispatch = useDispatch()
-  const reduxUser = useSelector<UserState, ModtreeApiResponse.User>(
-    (state) => state.base.user
-  )
-
-  const getBaseUserData = async (email: string) => {
-    const backend = process.env.NEXT_PUBLIC_BACKEND
-    axios
-      .post(`${backend}/user/get-by-email`, {
-        email,
-      })
-      .then((res) => {
-        dispatch(setBaseUser(res.data))
-      })
-      .catch(() => console.log('User not found. Own time own target carry on.'))
-  }
-
-  useEffect(() => {
-    if (user && user.email) getBaseUserData(user.email)
-  }, [user])
+  console.log(user.modtree)
 
   const menuItems = [
     { text: 'Your profile', callback: () => dispatch(showUserProfile()) },
@@ -59,14 +38,14 @@ export default function SignedInCircle() {
         <Menu.Item>
           <div className="px-4 py-3 text-sm text-gray-900">
             <div className="flex w-full">Signed in as</div>
-            <div className="flex w-full font-bold">{user?.email}</div>
+            <div className="flex w-full font-bold">{user.email}</div>
           </div>
         </Menu.Item>
       </div>
       <div>
         <Menu.Item>
           <div className="px-4 py-3 text-sm text-gray-900">
-            <div className="flex w-full">Username: {reduxUser.username}</div>
+            <div className="flex w-full">Username: {user.modtree.email}</div>
           </div>
         </Menu.Item>
       </div>

--- a/apps/web/components/buttons/FloatingUserButton/SignedIn.tsx
+++ b/apps/web/components/buttons/FloatingUserButton/SignedIn.tsx
@@ -1,17 +1,14 @@
 import { IoPerson } from 'react-icons/io5'
 import { useUser } from '@/utils/auth0'
-import { Menu } from '@headlessui/react'
-import { createRef } from 'react'
-import DropdownMenu, { MenuLink } from './DropdownMenu'
+import UserMenu from './UserMenu'
 import { useDispatch } from 'react-redux'
-import { showUserProfile } from '@/store/modal'
+import UserMenuItems from './UserMenuItems'
 
-function UserCircleArea() {
-  const bg = 'bg-gradient-to-r from-pink-400 to-orange-400'
+function UserCircle() {
   const position = 'flex justify-center items-center'
   {
     return (
-      <div className={`w-10 h-10 rounded-full ${bg} ${position}`}>
+      <div className={`w-10 h-10 rounded-full modtree-gradient ${position}`}>
         <IoPerson className="text-gray-50 h-5 w-5" />
       </div>
     )
@@ -21,51 +18,10 @@ function UserCircleArea() {
 export default function SignedInCircle() {
   const { user } = useUser()
   const dispatch = useDispatch()
-  console.log(user.modtree)
-
-  const menuItems = [
-    { text: 'Your profile', callback: () => dispatch(showUserProfile()) },
-    { text: 'Settings', callback: () => alert('open settings') },
-    {
-      text: 'Sign out',
-      href: '/api/auth/logout',
-    },
-  ]
 
   return (
-    <DropdownMenu TriggerButton={UserCircleArea}>
-      <div>
-        <Menu.Item>
-          <div className="px-4 py-3 text-sm text-gray-900">
-            <div className="flex w-full">Signed in as</div>
-            <div className="flex w-full font-bold">{user.email}</div>
-          </div>
-        </Menu.Item>
-      </div>
-      <div>
-        <Menu.Item>
-          <div className="px-4 py-3 text-sm text-gray-900">
-            <div className="flex w-full">Username: {user.modtree.email}</div>
-          </div>
-        </Menu.Item>
-      </div>
-      <div className="py-2">
-        {menuItems.map((menuItem, index) => {
-          const ref = createRef<HTMLAnchorElement>()
-          return (
-            <Menu.Item key={`${menuItem.text}-${index}`}>
-              <MenuLink
-                ref={ref}
-                href={menuItem.href || ''}
-                className="hover:bg-modtree-400/80 hover:text-white text-gray-900 flex w-full px-4 py-1.5 text-sm"
-                onClick={menuItem.callback}
-              >
-                {menuItem.text}
-              </MenuLink>
-            </Menu.Item>
-          )
-        })}
-      </div>
-    </DropdownMenu>
+    <UserMenu TriggerButton={UserCircle}>
+      <UserMenuItems user={user} dispatch={dispatch} />
+    </UserMenu>
   )
 }

--- a/apps/web/components/buttons/FloatingUserButton/SignedOut.tsx
+++ b/apps/web/components/buttons/FloatingUserButton/SignedOut.tsx
@@ -2,10 +2,10 @@ import Link from 'next/link'
 
 export default function SignedOutRect() {
   return (
-    <div className="inline-flex h-10 items-center rounded-md bg-black bg-opacity-20 px-4 py-2 text-sm font-medium text-white hover:bg-opacity-30 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75">
-      <Link href="/api/auth/login" passHref>
-        <a>Sign in</a>
-      </Link>
-    </div>
+    <Link href="/api/auth/login" passHref>
+      <a className="inline-flex h-10 items-center rounded-md bg-black bg-opacity-20 px-4 py-2 text-sm font-medium text-white hover:bg-opacity-30 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75">
+        Sign in
+      </a>
+    </Link>
   )
 }

--- a/apps/web/components/buttons/FloatingUserButton/UserMenu.tsx
+++ b/apps/web/components/buttons/FloatingUserButton/UserMenu.tsx
@@ -1,35 +1,7 @@
 import { Menu, Transition } from '@headlessui/react'
-import Link from 'next/link'
-import { FC, ForwardedRef, forwardRef, Fragment, ReactElement } from 'react'
+import { FC, Fragment, ReactElement } from 'react'
 
-function getMenuLink() {
-  const MenuLink = forwardRef(
-    (
-      props: {
-        href: string
-        children: string
-        className: string
-        onClick: () => void
-      },
-      ref: ForwardedRef<HTMLAnchorElement>
-    ) => {
-      const { href, children, className, onClick } = props
-      return (
-        <Link href={href} passHref>
-          <a className={className} onClick={onClick} ref={ref}>
-            {children}
-          </a>
-        </Link>
-      )
-    }
-  )
-  MenuLink.displayName = 'MenuLink'
-  return MenuLink
-}
-
-export const MenuLink = getMenuLink()
-
-export default function DropdownMenu(props: {
+export default function UserMenu(props: {
   TriggerButton: FC
   children: ReactElement[] | ReactElement
 }) {

--- a/apps/web/components/buttons/FloatingUserButton/UserMenuItems.tsx
+++ b/apps/web/components/buttons/FloatingUserButton/UserMenuItems.tsx
@@ -1,0 +1,61 @@
+import { Menu } from '@headlessui/react'
+import { createRef } from 'react'
+import { ModtreeUserContext } from 'types'
+import { MenuLink } from './MenuLink'
+import { Dispatch } from 'redux'
+import { showUserProfile } from '@/store/modal'
+
+export default function UserMenuItems(props: {
+  dispatch: Dispatch
+  user: ModtreeUserContext['user']
+}) {
+  const { dispatch, user } = props
+  const menuItems = [
+    { text: 'Your profile', callback: () => dispatch(showUserProfile()) },
+    { text: 'Settings', callback: () => alert('open settings') },
+    {
+      text: 'Sign out',
+      href: '/api/auth/logout',
+    },
+  ]
+
+  return (
+    <>
+      <div>
+        <Menu.Item>
+          <div className="px-4 py-3 text-sm text-gray-900">
+            <div className="flex w-full">Signed in as</div>
+            <div className="flex w-full font-bold">{user.email}</div>
+          </div>
+        </Menu.Item>
+      </div>
+      <div>
+        <Menu.Item>
+          <div className="px-4 py-3 text-sm text-gray-900">
+            <div className="flex w-full">Username: {user.modtree.email}</div>
+          </div>
+        </Menu.Item>
+      </div>
+      <div className="py-2">
+        {menuItems.map((menuItem, index) => {
+          const ref = createRef<HTMLAnchorElement>()
+          const className =
+            'hover:bg-modtree-400/80 hover:text-white ' +
+            'text-gray-900 flex w-full px-4 py-1.5 text-sm'
+          return (
+            <Menu.Item key={`${menuItem.text}-${index}`}>
+              <MenuLink
+                ref={ref}
+                href={menuItem.href || ''}
+                className={className}
+                onClick={menuItem.callback}
+              >
+                {menuItem.text}
+              </MenuLink>
+            </Menu.Item>
+          )
+        })}
+      </div>
+    </>
+  )
+}

--- a/apps/web/components/buttons/FloatingUserButton/UserMenuItems.tsx
+++ b/apps/web/components/buttons/FloatingUserButton/UserMenuItems.tsx
@@ -3,7 +3,7 @@ import { createRef } from 'react'
 import { ModtreeUserContext } from 'types'
 import { MenuLink } from './MenuLink'
 import { Dispatch } from 'redux'
-import { showUserProfile } from '@/store/modal'
+import { showDebugModal, showUserProfile } from '@/store/modal'
 
 export default function UserMenuItems(props: {
   dispatch: Dispatch
@@ -18,6 +18,12 @@ export default function UserMenuItems(props: {
       href: '/api/auth/logout',
     },
   ]
+  if (process.env['NODE_ENV'] === 'development') {
+    menuItems.splice(1, 0, {
+      text: 'Debug',
+      callback: () => dispatch(showDebugModal()),
+    })
+  }
 
   return (
     <>

--- a/apps/web/components/modals/Debug/index.tsx
+++ b/apps/web/components/modals/Debug/index.tsx
@@ -1,0 +1,72 @@
+import { Dialog, Transition } from '@headlessui/react'
+import { Fragment } from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+import { ModalState, hideDebugModal } from '@/store/modal'
+import { CloseButton } from '@/ui/buttons'
+import { useUser } from '@/utils/auth0'
+
+export default function DebugModal() {
+  const { user } = useUser()
+  const showDebugModal = useSelector<ModalState, boolean>(
+    (state) => state.modal.showDebugModal
+  )
+  const dispatch = useDispatch()
+
+  function closeModal() {
+    dispatch(hideDebugModal())
+  }
+
+  const DebugModalContents = () => {
+    return (
+      <div className="mt-2 border border-blue-400">
+        <code>useUser().user</code>
+        <pre className="p-2 bg-gray-100 overflow-hidden">
+          {JSON.stringify(user, null, 2)}
+        </pre>
+      </div>
+    )
+  }
+
+  const Panel = () => {
+    return (
+      <Transition.Child
+        as={Fragment}
+        enter="ease-out duration-300"
+        enterFrom="opacity-0 scale-95"
+        enterTo="opacity-100 scale-100"
+        leave="ease-in duration-200"
+        leaveFrom="opacity-100 scale-100"
+        leaveTo="opacity-0 scale-95"
+      >
+        <Dialog.Panel className="overflow-y-auto w-full max-w-4xl transform rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all">
+          <CloseButton close={closeModal} />
+          <h2 className="text-lg font-medium leading-6 text-gray-900 mb-4">
+            Debug
+          </h2>
+          <DebugModalContents />
+        </Dialog.Panel>
+      </Transition.Child>
+    )
+  }
+
+  return (
+    <Transition appear show={showDebugModal} as={Fragment}>
+      <Dialog as="div" className="relative z-10" onClose={closeModal}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-gray-900 bg-opacity-10" />
+        </Transition.Child>
+        <div className="fixed inset-0 overflow-hidden flex justify-center py-28">
+          <Panel />
+        </div>
+      </Dialog>
+    </Transition>
+  )
+}

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -4,6 +4,7 @@ import Header from '@/components/header'
 import UserProfileModal from '@/components/modals/UserProfile'
 import ModuleModal from '@/components/modals/ModuleInfo'
 import ModtreeFlow from '../flow'
+import DebugModal from '@/components/modals/Debug'
 
 export default function Modtree() {
   return (
@@ -15,6 +16,7 @@ export default function Modtree() {
         <FloatingActionButton />
       </FullScreenOverlay>
       <UserProfileModal />
+      <DebugModal />
       <ModuleModal />
     </div>
   )

--- a/apps/web/store/modal.ts
+++ b/apps/web/store/modal.ts
@@ -5,6 +5,7 @@ import { EmptyResponse } from '@modtree/utils'
 type State = {
   showUserProfile: boolean
   showModuleModal: boolean
+  showDebugModal: boolean
   modalModule: ModtreeApiResponse.Module
 }
 
@@ -15,6 +16,7 @@ export type ModalState = {
 const initialState: State = {
   showUserProfile: false,
   showModuleModal: false,
+  showDebugModal: false,
   modalModule: EmptyResponse.Module,
 }
 
@@ -34,6 +36,12 @@ export const modal = createSlice({
     showModuleModal: (state) => {
       state.showModuleModal = true
     },
+    hideDebugModal: (state) => {
+      state.showDebugModal = false
+    },
+    showDebugModal: (state) => {
+      state.showDebugModal = true
+    },
     setModalModule: (
       state,
       action: PayloadAction<ModtreeApiResponse.Module>
@@ -49,5 +57,7 @@ export const {
   showModuleModal,
   hideModuleModal,
   setModalModule,
+  hideDebugModal,
+  showDebugModal,
 } = modal.actions
 export default modal.reducer

--- a/apps/web/types/index.d.ts
+++ b/apps/web/types/index.d.ts
@@ -22,3 +22,9 @@ export type ModtreeUserContext = {
   isLoading: boolean
   checkSession: () => Promise<void>
 }
+
+export type UserMenuItem = {
+  text: string
+  href?: string
+  callback?: () => void
+}


### PR DESCRIPTION
### Summary of changes

- for `NODE_ENV` as `development`, there will be an extra option in the user menu: Debug.
- Currently shows the contents of `useUser().user`, the user of the useUser hook.

### Testing

- sign out and sign in and see if the `modtree` key of the user in the debug modal is populated.
