### PR TITLE
feat: generating schema from example response

### DIFF
--- a/apps/docs/data/degree/get.ts
+++ b/apps/docs/data/degree/get.ts
@@ -1,3 +1,31 @@
+import { generateSchema } from 'utils'
+
+const fulfilled = {
+  id: 'ea65f888-cde5-424e-9fa4-552ecc9ad275',
+  title: 'Computer Science',
+  modules: [
+    'CS1101S',
+    'CS1231S',
+    'CS2030S',
+    'CS2040S',
+    'CS2100',
+    'CS2103T',
+    'CS2106',
+    'CS2109S',
+    'CS3230',
+    'CP3106',
+    'CP3209',
+    'CP4101',
+    'CP4106',
+    'CP3200',
+    'CP3202',
+    'CP3107',
+    'CP3110',
+    'IS4010',
+    'TR3202',
+  ],
+}
+
 export const get: MethodProps = {
   method: 'Get a degree',
   description: 'Retrieve information about one degree',
@@ -14,35 +42,7 @@ export const get: MethodProps = {
     ],
   },
   response: {
-    fulfilled: {
-      id: 'ea65f888-cde5-424e-9fa4-552ecc9ad275',
-      title: 'Computer Science',
-      modules: [
-        'CS1101S',
-        'CS1231S',
-        'CS2030S',
-        'CS2040S',
-        'CS2100',
-        'CS2103T',
-        'CS2106',
-        'CS2109S',
-        'CS3230',
-        'CP3106',
-        'CP3209',
-        'CP4101',
-        'CP4106',
-        'CP3200',
-        'CP3202',
-        'CP3107',
-        'CP3110',
-        'IS4010',
-        'TR3202',
-      ],
-    },
-    schema: {
-      id: 'string',
-      title: 'string',
-      modules: 'string[]',
-    },
+    fulfilled,
+    schema: generateSchema(fulfilled),
   },
 }

--- a/apps/docs/data/graph/get.ts
+++ b/apps/docs/data/graph/get.ts
@@ -6,6 +6,25 @@ const fulfilled = {
   degree: 'Mathematics',
   modulesPlaced: ['MA2001', 'MA2002'],
   modulesHidden: ['CS2040S'],
+  flowNodes: [
+    {
+      moduleCode: 'CS1010',
+      title: 'Programming Methodology',
+      position: { x: 100, y: 200 },
+    },
+    {
+      moduleCode: 'CS2030S',
+      title: 'Programming Methodology II',
+      position: { x: 450, y: 100 },
+    },
+  ],
+  flowEdges: [
+    {
+      id: 'CS1010-CS2030S',
+      source: 'CS1010',
+      target: 'CS2030S',
+    },
+  ],
 }
 
 export const get: MethodProps = {

--- a/apps/docs/data/graph/get.ts
+++ b/apps/docs/data/graph/get.ts
@@ -1,3 +1,13 @@
+import { generateSchema } from 'utils'
+
+const fulfilled = {
+  id: 'ab0b6e0d-19cc-4c2e-ad7b-7e840cb04f38',
+  user: 'nguyenvukhang',
+  degree: 'Mathematics',
+  modulesPlaced: ['MA2001', 'MA2002'],
+  modulesHidden: ['CS2040S'],
+}
+
 export const get: MethodProps = {
   method: 'Get a Graph',
   description: 'Retrieve information about one Graph.',
@@ -14,19 +24,7 @@ export const get: MethodProps = {
     ],
   },
   response: {
-    fulfilled: {
-      id: 'ab0b6e0d-19cc-4c2e-ad7b-7e840cb04f38',
-      user: 'nguyenvukhang',
-      degree: 'Mathematics',
-      modulesPlaced: ['MA2001', 'MA2002'],
-      modulesHidden: ['CS2040S'],
-    },
-    schema: {
-      id: 'string',
-      user: 'string',
-      degree: 'string',
-      modulesPlaced: 'string[]',
-      modulesHidden: 'string[]',
-    },
+    fulfilled,
+    schema: generateSchema(fulfilled),
   },
 }

--- a/apps/docs/data/module-condensed/get.ts
+++ b/apps/docs/data/module-condensed/get.ts
@@ -1,3 +1,12 @@
+import { generateSchema } from 'utils'
+
+const fulfilled = {
+  id: 'fff52647-b948-43c3-a796-a81495d7a715',
+  moduleCode: 'CS1010S',
+  moduleLevel: 1010,
+  title: 'Programming Methodology',
+}
+
 export const get: MethodProps = {
   method: 'Get a module condensed',
   description: 'Retrieve basic information about one module',
@@ -14,17 +23,7 @@ export const get: MethodProps = {
     ],
   },
   response: {
-    fulfilled: {
-      id: 'fff52647-b948-43c3-a796-a81495d7a715',
-      moduleCode: 'CS1010S',
-      moduleLevel: 1010,
-      title: 'Programming Methodology',
-    },
-    schema: {
-      id: 'string',
-      moduleCode: 'string',
-      moduleLevel: 'number',
-      title: 'string',
-    },
+    fulfilled,
+    schema: generateSchema(fulfilled),
   },
 }

--- a/apps/docs/data/module/get.ts
+++ b/apps/docs/data/module/get.ts
@@ -1,3 +1,43 @@
+import { generateSchema } from 'utils'
+
+const fulfilled = {
+  id: 'fff52647-b948-43c3-a796-a81495d7a715',
+  moduleCode: 'CS1010S',
+  title: 'Programming Methodology',
+  acadYear: '2021/2022',
+  description:
+    'This module introduces the fundamental concepts of problem solving ' +
+    'by computing and programming using an imperative programming ' +
+    'language. It is the first and \nforemost introductory course to ' +
+    'computing and is equivalent to CS1010 and CS1010E Programming ' +
+    'Methodology. Topics covered include problem solving by computing, ' +
+    'writing pseudo-codes, basic problem formulation and problem ' +
+    'solving, program development, coding, testing and debugging, ' +
+    'fundamental programming constructs (variables, types, expressions, ' +
+    'assignments, functions, control structures, etc.), fundamental ' +
+    'data structures: arrays, strings and structures, simple file ' +
+    'processing, and basic recursion. This module is appropriate for ' +
+    'FoS students.',
+  moduleCredit: 4,
+  department: 'Computer Science',
+  faculty: 'Computing',
+  prerequisite: '',
+  corequisite: '',
+  preclusion: 'CS1010, CS1010E, CS1010J, CS1010X, CS1010XCP, CS1101S',
+  fulfillRequirements: [
+    'FIN4124',
+    'FIN4719',
+    'IT3010',
+    'ZB4171',
+    'MA3269',
+    'DSA3102',
+    'ST3247',
+    'QF2103',
+  ],
+  prereqTree: '',
+  workload: [2, 1, 1, 3, 3],
+}
+
 export const get: MethodProps = {
   method: 'Get a module',
   description: 'Retrieve full information about one module',
@@ -14,58 +54,7 @@ export const get: MethodProps = {
     ],
   },
   response: {
-    fulfilled: {
-      id: 'fff52647-b948-43c3-a796-a81495d7a715',
-      moduleCode: 'CS1010S',
-      title: 'Programming Methodology',
-      acadYear: '2021/2022',
-      description:
-        'This module introduces the fundamental concepts of problem solving ' +
-        'by computing and programming using an imperative programming ' +
-        'language. It is the first and \nforemost introductory course to ' +
-        'computing and is equivalent to CS1010 and CS1010E Programming ' +
-        'Methodology. Topics covered include problem solving by computing, ' +
-        'writing pseudo-codes, basic problem formulation and problem ' +
-        'solving, program development, coding, testing and debugging, ' +
-        'fundamental programming constructs (variables, types, expressions, ' +
-        'assignments, functions, control structures, etc.), fundamental ' +
-        'data structures: arrays, strings and structures, simple file ' +
-        'processing, and basic recursion. This module is appropriate for ' +
-        'FoS students.',
-      moduleCredit: 4,
-      department: 'Computer Science',
-      faculty: 'Computing',
-      prerequisite: '',
-      corequisite: '',
-      preclusion: 'CS1010, CS1010E, CS1010J, CS1010X, CS1010XCP, CS1101S',
-      fulfillRequirements: [
-        'FIN4124',
-        'FIN4719',
-        'IT3010',
-        'ZB4171',
-        'MA3269',
-        'DSA3102',
-        'ST3247',
-        'QF2103',
-      ],
-      prereqTree: '',
-      workload: [2, 1, 1, 3, 3],
-    },
-    schema: {
-      id: 'string',
-      moduleCode: 'string',
-      title: 'string',
-      acadYear: 'string',
-      description: 'string',
-      moduleCredit: 'number',
-      department: 'string',
-      faculty: 'string',
-      prerequisite: 'string',
-      corequisite: 'string',
-      preclusion: 'string',
-      fulfillRequirements: 'string[]',
-      prereqTree: 'json-tree',
-      workload: 'number[]',
-    },
+    fulfilled,
+    schema: generateSchema(fulfilled),
   },
 }

--- a/apps/docs/data/user/get.ts
+++ b/apps/docs/data/user/get.ts
@@ -1,3 +1,22 @@
+import { generateSchema } from 'utils'
+
+const fulfilled = {
+  authZeroId: 'auth0|6294dbffdc4dea0068d77f61',
+  displayName: 'Nguyen Vu Khang',
+  username: 'nguyenvukhang',
+  email: 'khang@modtree.com',
+  modulesDone: ['MA1100', 'CS1010S'],
+  modulesDoing: ['MA2219'],
+  matriculationYear: 2021,
+  graduationYear: 2024,
+  graduationSemester: 2,
+  savedDegrees: [
+    'cb70ebf4-6733-4bcf-b605-a98170f6f0e2',
+    'ab4eceaf-ee9c-4032-88dd-687b38322249',
+  ],
+  savedGraphs: [],
+}
+
 export const get: MethodProps = {
   method: 'Get a user',
   description: 'Retrieve information about one user',
@@ -14,28 +33,7 @@ export const get: MethodProps = {
     ],
   },
   response: {
-    fulfilled: {
-      displayName: 'Nguyen Vu Khang',
-      username: 'nguyenvukhang',
-      modulesDone: ['MA1100', 'CS1010S'],
-      modulesDoing: ['MA2219'],
-      matriculationYear: 2021,
-      graduationYear: 2024,
-      graduationSemester: 2,
-      savedDegrees: [
-        'cb70ebf4-6733-4bcf-b605-a98170f6f0e2',
-        'ab4eceaf-ee9c-4032-88dd-687b38322249',
-      ],
-    },
-    schema: {
-      displayName: 'string',
-      username: 'string',
-      modulesDone: 'string[]',
-      modulesDoing: 'string[]',
-      matriculationYear: 'number',
-      graduationYear: 'number',
-      graduationSemester: 'number',
-      savedDegrees: 'string[]',
-    },
+    fulfilled,
+    schema: generateSchema(fulfilled),
   },
 }

--- a/apps/docs/data/user/get.ts
+++ b/apps/docs/data/user/get.ts
@@ -14,7 +14,7 @@ const fulfilled = {
     'cb70ebf4-6733-4bcf-b605-a98170f6f0e2',
     'ab4eceaf-ee9c-4032-88dd-687b38322249',
   ],
-  savedGraphs: [],
+  savedGraphs: ['4dcf096d-fc1a-4b01-99df-17cc01cba16c'],
 }
 
 export const get: MethodProps = {

--- a/apps/docs/types.d.ts
+++ b/apps/docs/types.d.ts
@@ -2,7 +2,20 @@ type CustomError = 'Not found' | 'Database Error'
 
 type RequestType = 'POST' | 'GET' | 'DELETE'
 
-type Data = string | number | string[] | number[]
+type Data = string | number | string[] | number[] | Record<string, any>
+
+type SchemaItem = SchemaObject | SchemaNonObject | {}
+
+type SchemaNonObject = {
+  type: string
+  items?: SchemaItem // this param
+}
+
+type SchemaObject = {
+  // for objects in the schema
+  type: string
+  properties: Record<string, SchemaItem>
+}
 
 type MethodProps = {
   method: string // short description
@@ -18,7 +31,7 @@ type MethodProps = {
 
 type ResponseProps = {
   fulfilled: Record<string, Data>
-  schema: Record<string, Data>
+  schema: SchemaItem
 }
 
 type Parameter = {

--- a/apps/docs/utils/index.ts
+++ b/apps/docs/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './schema'

--- a/apps/docs/utils/schema.ts
+++ b/apps/docs/utils/schema.ts
@@ -1,12 +1,10 @@
 export function generateSchema(sampleResponse: any): SchemaItem {
   let schema = {}
 
-  // handle string separately
-  // because Object.entries makes string be treated as
-  // array of chars
-  if (typeof sampleResponse === 'string')
+  // handle non objects separately
+  if (typeof sampleResponse !== 'object')
     return {
-      type: 'string',
+      type: typeof sampleResponse,
     }
 
   // Assume for now we can only have arrays on

--- a/apps/docs/utils/schema.ts
+++ b/apps/docs/utils/schema.ts
@@ -1,4 +1,4 @@
-export function generateSchema(sampleResponse: any) {
+export function generateSchema(sampleResponse: any): SchemaItem {
   let schema = {}
 
   // handle string separately

--- a/apps/docs/utils/schema.ts
+++ b/apps/docs/utils/schema.ts
@@ -1,0 +1,42 @@
+export function generateSchema(sampleResponse: any) {
+  let schema = {}
+
+  // handle string separately
+  // because Object.entries makes string be treated as
+  // array of chars
+  if (typeof sampleResponse === 'string')
+    return {
+      type: 'string',
+    }
+
+  // Assume for now we can only have arrays on
+  // the first layer keys of API response
+  Object.entries(sampleResponse).forEach(([key, value]) => {
+    if (value instanceof Array) {
+      let items
+      // assume that array is not empty
+      if (value[0] instanceof Object) {
+        items = {
+          type: 'object',
+          properties: generateSchema(value[0]),
+        }
+      } else {
+        items = generateSchema(value[0])
+      }
+      schema[key] = {
+        type: 'array',
+        items,
+      }
+    } else if (value instanceof Object) {
+      schema[key] = {
+        type: 'object',
+        properties: generateSchema(value),
+      }
+    } else {
+      schema[key] = {
+        type: typeof value,
+      }
+    }
+  })
+  return schema
+}


### PR DESCRIPTION
### Summary of changes

- Created util that generates schema given example response
- Used util in all current API docs
- Updated User get and Graph get responses

### Notes

I tried some libraries, but I felt that we just need something simple, so we can write our own util.

1. [generate-schema](https://www.npmjs.com/package/generate-schema)
- Doesn't seem to work well with TypeScript. I couldn't get it to work
2. [json-schema-generator](https://www.npmjs.com/package/json-schema-generator)
- I got it to return a schema, but it wasn't able to detect array contents.
- The schema produced is quite verbose, not clear what I can configure

### Testing

- Compare example responses and the schemas
- Compare example responses in docs and responses from postman
