### PR TITLE
fix: Degree delete endpoint

### DIFF
--- a/apps/docs/project.json
+++ b/apps/docs/project.json
@@ -45,5 +45,6 @@
       }
     }
   },
-  "tags": []
+  "tags": [],
+  "implicitDependencies": ["!test-env"]
 }

--- a/apps/server/project.json
+++ b/apps/server/project.json
@@ -47,5 +47,6 @@
       }
     }
   },
-  "tags": []
+  "tags": [],
+  "implicitDependencies": ["!test-env"]
 }

--- a/apps/server/src/controller/Degree.ts
+++ b/apps/server/src/controller/Degree.ts
@@ -66,20 +66,14 @@ export class DegreeController implements IDegreeController {
    * @param {Response} res
    */
   async delete(req: Request, res: Response) {
-    const degree = await this.degreeRepo.findOneById(req.params.id)
-    const removeResult = await this.degreeRepo.remove(degree)
-    res.json(removeResult)
-    /*
     this.degreeRepo
-      .delete({
-        id: req.params.degreeId,
-      })
-      .then((deleteResult) => {
-        res.json({ deleteResult })
+      .findOneById(req.params.id)
+      .then((degree) => this.degreeRepo.remove(degree))
+      .then((degree) => {
+        res.json(flatten.degree(degree))
       })
       .catch(() => {
         res.status(404).json({ message: 'Degree not found' })
       })
-      */
   }
 }

--- a/apps/server/src/controller/Degree.ts
+++ b/apps/server/src/controller/Degree.ts
@@ -66,6 +66,10 @@ export class DegreeController implements IDegreeController {
    * @param {Response} res
    */
   async delete(req: Request, res: Response) {
+    const degree = await this.degreeRepo.findOneById(req.params.id)
+    const removeResult = await this.degreeRepo.remove(degree)
+    res.json(removeResult)
+    /*
     this.degreeRepo
       .delete({
         id: req.params.degreeId,
@@ -76,5 +80,6 @@ export class DegreeController implements IDegreeController {
       .catch(() => {
         res.status(404).json({ message: 'Degree not found' })
       })
+      */
   }
 }

--- a/apps/web/project.json
+++ b/apps/web/project.json
@@ -38,5 +38,6 @@
       }
     }
   },
-  "tags": []
+  "tags": [],
+  "implicitDependencies": ["!test-env"]
 }

--- a/libs/entity/project.json
+++ b/libs/entity/project.json
@@ -30,5 +30,6 @@
       }
     }
   },
-  "tags": []
+  "tags": [],
+  "implicitDependencies": ["!test-env"]
 }

--- a/libs/entity/src/Graph.ts
+++ b/libs/entity/src/Graph.ts
@@ -25,7 +25,7 @@ export class Graph implements IGraph {
   @JoinTable()
   user: IUser
 
-  @ManyToOne('Degree', 'graph')
+  @ManyToOne('Degree', 'graph', { onDelete: 'CASCADE' })
   @JoinTable()
   degree: IDegree
 

--- a/libs/repo-api/project.json
+++ b/libs/repo-api/project.json
@@ -31,5 +31,6 @@
       }
     }
   },
-  "tags": []
+  "tags": [],
+  "implicitDependencies": ["!test-env"]
 }

--- a/libs/repo-api/test/degree-delete.test.ts
+++ b/libs/repo-api/test/degree-delete.test.ts
@@ -1,9 +1,9 @@
-import { User, Graph } from '@modtree/entity'
+import { User } from '@modtree/entity'
 import { setup, teardown, Repo, t, init } from '@modtree/test-env'
 import { oneUp } from '@modtree/utils'
 import { getSource } from '@modtree/typeorm-config'
-import { DegreeRepository } from '../src'
 import { UserRepository } from '@modtree/repo-user'
+import { DegreeRepository } from '@modtree/repo-degree'
 import { GraphRepository } from '@modtree/repo-graph'
 
 const dbName = oneUp(__filename)

--- a/libs/repo-base/project.json
+++ b/libs/repo-base/project.json
@@ -31,5 +31,6 @@
       }
     }
   },
-  "tags": []
+  "tags": [],
+  "implicitDependencies": ["!test-env"]
 }

--- a/libs/repo-degree/project.json
+++ b/libs/repo-degree/project.json
@@ -31,5 +31,6 @@
       }
     }
   },
-  "tags": []
+  "tags": [],
+  "implicitDependencies": ["!test-env"]
 }

--- a/libs/repo-degree/test/delete.test.ts
+++ b/libs/repo-degree/test/delete.test.ts
@@ -2,9 +2,6 @@ import { User } from '@modtree/entity'
 import { setup, teardown, Repo, t, init } from '@modtree/test-env'
 import { oneUp } from '@modtree/utils'
 import { getSource } from '@modtree/typeorm-config'
-import { UserRepository } from '@modtree/repo-user'
-import { DegreeRepository } from '@modtree/repo-degree'
-import { GraphRepository } from '@modtree/repo-graph'
 
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
@@ -12,11 +9,6 @@ const db = getSource(dbName)
 beforeAll(() =>
   setup(db)
     .then(() => {
-      Object.assign(Repo, {
-        User: new UserRepository(db),
-        Degree: new DegreeRepository(db),
-        Graph: new GraphRepository(db),
-      })
       return Promise.all([
         Repo.User!.initialize(init.user1),
         Repo.Degree!.initialize(init.degree1),

--- a/libs/repo-degree/test/delete.test.ts
+++ b/libs/repo-degree/test/delete.test.ts
@@ -1,0 +1,79 @@
+import { User, Graph } from '@modtree/entity'
+import { setup, teardown, Repo, t, init } from '@modtree/test-env'
+import { oneUp } from '@modtree/utils'
+import { getSource } from '@modtree/typeorm-config'
+import { DegreeRepository } from '../src'
+import { UserRepository } from '@modtree/repo-user'
+import { GraphRepository } from '@modtree/repo-graph'
+
+const dbName = oneUp(__filename)
+const db = getSource(dbName)
+
+beforeAll(() =>
+  setup(db)
+    .then(() => {
+      Object.assign(Repo, {
+        User: new UserRepository(db),
+        Degree: new DegreeRepository(db),
+        Graph: new GraphRepository(db),
+      })
+      return Promise.all([
+        Repo.User!.initialize(init.user1),
+        Repo.Degree!.initialize(init.degree1),
+      ])
+    })
+    .then(([user, degree]) => {
+      t.user = user
+      t.degree = degree
+      return Repo.User!.addDegree(t.user, t.degree.id)
+    })
+    .then(() =>
+      Repo.Graph!.initialize({
+        userId: t.user!.id,
+        degreeId: t.degree!.id,
+        modulesPlacedCodes: [],
+        modulesHiddenCodes: [],
+        pullAll: false,
+      })
+    )
+    .then((graph) => {
+      t.graph = graph
+    })
+)
+afterAll(() => teardown(db))
+
+it('user has 1 degree', async () => {
+  await Repo.User!.findOneById(t.user!.id).then((user) => {
+    expect(user.savedDegrees).toHaveLength(1)
+  })
+})
+
+it('successfully deletes', async () => {
+  await Repo.Degree!.remove(t.degree!).then((degree) => {
+    expect(degree.id).toEqual(undefined)
+  })
+})
+
+it('degree does not exist', async () => {
+  await expect(() => Repo.Degree!.findOneById(t.degree!.id)).rejects.toThrow(
+    Error
+  )
+})
+
+it('user exists', async () => {
+  await Repo.User!.findOneById(t.user!.id).then((user) => {
+    expect(user).toBeInstanceOf(User)
+  })
+})
+
+it('user has 0 degrees', async () => {
+  await Repo.User!.findOneById(t.user!.id).then((user) => {
+    expect(user.savedDegrees).toHaveLength(0)
+  })
+})
+
+it('graph does not exist', async () => {
+  await expect(() => Repo.Graph!.findOneById(t.graph!.id)).rejects.toThrow(
+    Error
+  )
+})

--- a/libs/repo-degree/test/initialize.test.ts
+++ b/libs/repo-degree/test/initialize.test.ts
@@ -2,16 +2,11 @@ import { Degree } from '@modtree/entity'
 import { setup, teardown, Repo, t } from '@modtree/test-env'
 import { flatten, oneUp } from '@modtree/utils'
 import { getSource } from '@modtree/typeorm-config'
-import { DegreeRepository } from '../src'
 
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
 
-beforeAll(() =>
-  setup(db).then(() => {
-    Repo.Degree = new DegreeRepository(db)
-  })
-)
+beforeAll(() => setup(db))
 afterAll(() => teardown(db))
 
 const props = {

--- a/libs/repo-degree/test/insert-modules.test.ts
+++ b/libs/repo-degree/test/insert-modules.test.ts
@@ -1,7 +1,6 @@
 import { setup, teardown, Repo, t } from '@modtree/test-env'
 import { flatten, oneUp } from '@modtree/utils'
 import { getSource } from '@modtree/typeorm-config'
-import { DegreeRepository } from '../src'
 import { Degree } from '@modtree/entity'
 
 const dbName = oneUp(__filename)
@@ -9,13 +8,12 @@ const db = getSource(dbName)
 
 beforeAll(() =>
   setup(db)
-    .then(() => {
-      Repo.Degree = new DegreeRepository(db)
-      return Repo.Degree!.initialize({
+    .then(() =>
+      Repo.Degree!.initialize({
         moduleCodes: [],
         title: 'Test Degree',
       })
-    })
+    )
     .then((degree) => {
       t.degree = degree
       t.combinedModuleCodes = degree.modules.map(flatten.module)

--- a/libs/repo-graph/project.json
+++ b/libs/repo-graph/project.json
@@ -30,5 +30,6 @@
       }
     }
   },
-  "tags": []
+  "tags": [],
+  "implicitDependencies": ["!test-env"]
 }

--- a/libs/repo-graph/test/get-suggest-modules-params.test.ts
+++ b/libs/repo-graph/test/get-suggest-modules-params.test.ts
@@ -1,9 +1,6 @@
 import { setup, teardown, t, init, Repo } from '@modtree/test-env'
 import { oneUp } from '@modtree/utils'
 import { getSource } from '@modtree/typeorm-config'
-import { UserRepository } from '@modtree/repo-user'
-import { DegreeRepository } from '@modtree/repo-degree'
-import { GraphRepository } from '../src'
 
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
@@ -33,15 +30,12 @@ const userProps = {
 
 beforeAll(() =>
   setup(db)
-    .then(() => {
-      Repo.User = new UserRepository(db)
-      Repo.Degree = new DegreeRepository(db)
-      Repo.Graph = new GraphRepository(db)
-      return Promise.all([
+    .then(() =>
+      Promise.all([
         Repo.User!.initialize(userProps),
         Repo.Degree!.initialize(degreeProps),
       ])
-    })
+    )
     .then(([user, degree]) => {
       t.user = user
       return Repo.Graph!.initialize({

--- a/libs/repo-graph/test/initialize/no-pull-all.test.ts
+++ b/libs/repo-graph/test/initialize/no-pull-all.test.ts
@@ -1,24 +1,18 @@
 import { oneUp } from '@modtree/utils'
 import { getSource } from '@modtree/typeorm-config'
 import { setup, teardown, Repo, t, init } from '@modtree/test-env'
-import { UserRepository } from '@modtree/repo-user'
-import { DegreeRepository } from '@modtree/repo-degree'
-import { GraphRepository } from '../../src'
 
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
 
 beforeAll(() =>
   setup(db)
-    .then(() => {
-      Repo.User = new UserRepository(db)
-      Repo.Degree = new DegreeRepository(db)
-      Repo.Graph = new GraphRepository(db)
-      return Promise.all([
+    .then(() =>
+      Promise.all([
         Repo.User!.initialize(init.user1),
         Repo.Degree!.initialize(init.degree1),
       ])
-    })
+    )
     .then(([user, degree]) => {
       t.user = user
       t.degree = degree

--- a/libs/repo-graph/test/initialize/pull-all.test.ts
+++ b/libs/repo-graph/test/initialize/pull-all.test.ts
@@ -2,20 +2,14 @@ import { flatten, oneUp } from '@modtree/utils'
 import { getSource } from '@modtree/typeorm-config'
 import { Graph } from '@modtree/entity'
 import { setup, teardown, Repo, t, init } from '@modtree/test-env'
-import { GraphRepository } from '../../src'
-import { DegreeRepository } from '@modtree/repo-degree'
-import { UserRepository } from '@modtree/repo-user'
 
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
 
 beforeAll(() =>
   setup(db)
-    .then(() => {
-      Repo.User = new UserRepository(db)
-      Repo.Degree = new DegreeRepository(db)
-      Repo.Graph = new GraphRepository(db)
-      return Promise.all([
+    .then(() =>
+      Promise.all([
         Repo.User!.initialize({
           ...init.user1,
           modulesDone: ['MA2001'],
@@ -26,7 +20,7 @@ beforeAll(() =>
           title: 'Test Degree',
         }),
       ])
-    })
+    )
     .then(([user, degree]) => {
       t.user = user
       t.degree = degree

--- a/libs/repo-module/project.json
+++ b/libs/repo-module/project.json
@@ -31,5 +31,6 @@
       }
     }
   },
-  "tags": []
+  "tags": [],
+  "implicitDependencies": ["!test-env"]
 }

--- a/libs/repo-module/src/utils/check-tree.spec.ts
+++ b/libs/repo-module/src/utils/check-tree.spec.ts
@@ -2,16 +2,11 @@ import { oneUp } from '@modtree/utils'
 import { getSource } from '@modtree/typeorm-config'
 import { setup, teardown, Repo } from '@modtree/test-env'
 import { checkTree } from '.'
-import { ModuleRepository } from '../Module'
 
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
 
-beforeAll(() =>
-  setup(db).then(() => {
-    Repo.Module = new ModuleRepository(db)
-  })
-)
+beforeAll(() => setup(db))
 afterAll(() => teardown(db))
 
 it('true for mods without pre-reqs', async () => {

--- a/libs/repo-module/src/utils/valid-module-code.spec.ts
+++ b/libs/repo-module/src/utils/valid-module-code.spec.ts
@@ -2,16 +2,11 @@ import { validModuleCode } from '.'
 import { oneUp } from '@modtree/utils'
 import { getSource } from '@modtree/typeorm-config'
 import { setup, teardown, Repo } from '@modtree/test-env'
-import { ModuleCondensedRepository } from '../ModuleCondensed'
 
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
 
-beforeAll(() =>
-  setup(db).then(() => {
-    Repo.ModuleCondensed = new ModuleCondensedRepository(db)
-  })
-)
+beforeAll(() => setup(db))
 afterAll(() => teardown(db))
 
 test('returns true on all existing codes', async () => {

--- a/libs/repo-module/test/module-condensed/fetch.test.ts
+++ b/libs/repo-module/test/module-condensed/fetch.test.ts
@@ -2,16 +2,11 @@ import { flatten, oneUp } from '@modtree/utils'
 import { getSource } from '@modtree/typeorm-config'
 import { ModuleCondensed } from '@modtree/entity'
 import { setup, teardown, Repo } from '@modtree/test-env'
-import { ModuleCondensedRepository } from '../../src/ModuleCondensed'
 
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
 
-beforeAll(() =>
-  setup(db).then(() => {
-    Repo.ModuleCondensed = new ModuleCondensedRepository(db)
-  })
-)
+beforeAll(() => setup(db))
 afterAll(() => teardown(db))
 
 test('moduleCondensed.fetch', async () => {

--- a/libs/repo-module/test/module-condensed/find-by-codes.test.ts
+++ b/libs/repo-module/test/module-condensed/find-by-codes.test.ts
@@ -1,17 +1,12 @@
 import { flatten, oneUp } from '@modtree/utils'
 import { getSource } from '@modtree/typeorm-config'
 import { Repo, setup, teardown, t } from '@modtree/test-env'
-import { ModuleCondensedRepository } from '../../src'
 import { ModuleCondensed } from '@modtree/entity'
 
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
 
-beforeAll(() =>
-  setup(db).then(() => {
-    Repo.ModuleCondensed = new ModuleCondensedRepository(db)
-  })
-)
+beforeAll(() => setup(db))
 afterAll(() => teardown(db))
 
 async function findByCodes(moduleCodes: string[]) {

--- a/libs/repo-module/test/module-condensed/get-codes.test.ts
+++ b/libs/repo-module/test/module-condensed/get-codes.test.ts
@@ -1,16 +1,11 @@
 import { oneUp } from '@modtree/utils'
 import { getSource } from '@modtree/typeorm-config'
 import { Repo, setup, teardown } from '@modtree/test-env'
-import { ModuleCondensedRepository } from '../../src'
 
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
 
-beforeAll(() =>
-  setup(db).then(() => {
-    Repo.ModuleCondensed = new ModuleCondensedRepository(db)
-  })
-)
+beforeAll(() => setup(db))
 afterAll(() => teardown(db))
 
 test('returns an array of strings', async () => {

--- a/libs/repo-module/test/module/can-take-module.test.ts
+++ b/libs/repo-module/test/module/can-take-module.test.ts
@@ -1,16 +1,11 @@
 import { setup, teardown, Repo } from '@modtree/test-env'
 import { oneUp } from '@modtree/utils'
 import { getSource } from '@modtree/typeorm-config'
-import { ModuleRepository } from '../../src'
 
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
 
-beforeAll(() =>
-  setup(db).then(() => {
-    Repo.Module = new ModuleRepository(db)
-  })
-)
+beforeAll(() => setup(db))
 afterAll(() => teardown(db))
 
 async function canTakeModule(done: string[], doing: string[], query: string) {

--- a/libs/repo-module/test/module/fetch.test.ts
+++ b/libs/repo-module/test/module/fetch.test.ts
@@ -2,16 +2,11 @@ import { Module } from '@modtree/entity'
 import { oneUp } from '@modtree/utils'
 import { getSource } from '@modtree/typeorm-config'
 import { setup, teardown, Repo, t } from '@modtree/test-env'
-import { ModuleRepository } from '../../src'
 
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
 
-beforeAll(() =>
-  setup(db).then(() => {
-    Repo.Module = new ModuleRepository(db)
-  })
-)
+beforeAll(() => setup(db))
 afterAll(() => teardown(db))
 
 test('returns a module', async () => {

--- a/libs/repo-module/test/module/find-by-faculty.test.ts
+++ b/libs/repo-module/test/module/find-by-faculty.test.ts
@@ -2,16 +2,11 @@ import { Module } from '@modtree/entity'
 import { oneUp } from '@modtree/utils'
 import { getSource } from '@modtree/typeorm-config'
 import { setup, teardown, Repo } from '@modtree/test-env'
-import { ModuleRepository } from '../../src'
 
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
 
-beforeAll(() =>
-  setup(db).then(() => {
-    Repo.Module = new ModuleRepository(db)
-  })
-)
+beforeAll(() => setup(db))
 afterAll(() => teardown(db))
 
 async function findByFaculty(faculty: string) {

--- a/libs/repo-module/test/module/get-eligible-modules.test.ts
+++ b/libs/repo-module/test/module/get-eligible-modules.test.ts
@@ -1,16 +1,11 @@
 import { setup, teardown, Repo, t } from '@modtree/test-env'
 import { oneUp } from '@modtree/utils'
 import { getSource } from '@modtree/typeorm-config'
-import { ModuleRepository } from '../../src'
 
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
 
-beforeAll(() =>
-  setup(db).then(() => {
-    Repo.Module = new ModuleRepository(db)
-  })
-)
+beforeAll(() => setup(db))
 afterAll(() => teardown(db))
 
 it('returns an array of strings', async () => {

--- a/libs/repo-module/test/module/get-postreqs.test.ts
+++ b/libs/repo-module/test/module/get-postreqs.test.ts
@@ -1,17 +1,12 @@
 import { setup, teardown, t, Repo } from '@modtree/test-env'
 import { oneUp, unique } from '@modtree/utils'
 import { getSource } from '@modtree/typeorm-config'
-import { ModuleRepository } from '../../src'
 import { In } from 'typeorm'
 
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
 
-beforeAll(() =>
-  setup(db).then(() => {
-    Repo.Module = new ModuleRepository(db)
-  })
-)
+beforeAll(() => setup(db))
 afterAll(() => teardown(db))
 
 describe('single query', () => {

--- a/libs/repo-module/test/module/get-suggested-modules/from-many.test.ts
+++ b/libs/repo-module/test/module/get-suggested-modules/from-many.test.ts
@@ -1,16 +1,11 @@
 import { setup, teardown, Repo, t } from '@modtree/test-env'
 import { oneUp } from '@modtree/utils'
 import { getSource } from '@modtree/typeorm-config'
-import { ModuleRepository } from '../../../src'
 
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
 
-beforeAll(() =>
-  setup(db).then(() => {
-    Repo.Module = new ModuleRepository(db)
-  })
-)
+beforeAll(() => setup(db))
 afterAll(() => teardown(db))
 
 it('returns an array of strings', async () => {

--- a/libs/repo-module/test/module/get-suggested-modules/from-one.test.ts
+++ b/libs/repo-module/test/module/get-suggested-modules/from-one.test.ts
@@ -1,16 +1,11 @@
 import { setup, teardown, t, Repo } from '@modtree/test-env'
 import { oneUp } from '@modtree/utils'
 import { getSource } from '@modtree/typeorm-config'
-import { ModuleRepository } from '../../../src'
 
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
 
-beforeAll(() =>
-  setup(db).then(() => {
-    Repo.Module = new ModuleRepository(db)
-  })
-)
+beforeAll(() => setup(db))
 afterAll(() => teardown(db))
 
 export async function suggest(

--- a/libs/repo-module/test/module/get-unlocked-modules.test.ts
+++ b/libs/repo-module/test/module/get-unlocked-modules.test.ts
@@ -1,16 +1,11 @@
 import { setup, teardown, Repo, t } from '@modtree/test-env'
 import { oneUp } from '@modtree/utils'
 import { getSource } from '@modtree/typeorm-config'
-import { ModuleRepository } from '../../src'
 
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
 
-beforeAll(() =>
-  setup(db).then(() => {
-    Repo.Module = new ModuleRepository(db)
-  })
-)
+beforeAll(() => setup(db))
 afterAll(() => teardown(db))
 
 async function getUnlockedModules(

--- a/libs/repo-module/test/pull/module-condensed.test.ts
+++ b/libs/repo-module/test/pull/module-condensed.test.ts
@@ -2,18 +2,11 @@ import { setup, teardown, Repo } from '@modtree/test-env'
 import { ModuleCondensed } from '@modtree/entity'
 import { oneUp } from '@modtree/utils'
 import { container, getSource } from '@modtree/typeorm-config'
-import { ModuleCondensedRepository } from '../../src/Module'
-
-const lowerBound = 6000
 
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
 
-beforeAll(() =>
-  setup(db).then(() => {
-    Repo.ModuleCondensed = new ModuleCondensedRepository(db)
-  })
-)
+beforeAll(() => setup(db))
 afterAll(() => teardown(db))
 
 test('moduleCondensed.pull', async () => {
@@ -25,11 +18,11 @@ test('moduleCondensed.pull', async () => {
   expect([pullOnFull, pullOnEmpty, written]).toBeDefined()
   if (!pullOnFull || !pullOnEmpty || !written) return
   /* make sure every element is a valid ModuleCondensed */
-  expect(pullOnEmpty.length).toBeGreaterThan(lowerBound)
+  expect(pullOnEmpty.length).toBeGreaterThan(6000)
   written.forEach((module) => {
     expect(module).toBeInstanceOf(ModuleCondensed)
   })
   const s = new Set(written)
   expect(s.size).toBe(written.length)
-  expect(s.size).toBeGreaterThan(lowerBound)
+  expect(s.size).toBeGreaterThan(6000)
 })

--- a/libs/repo-module/test/pull/module.test.ts
+++ b/libs/repo-module/test/pull/module.test.ts
@@ -2,19 +2,12 @@ import { Module } from '@modtree/entity'
 import { Repo, setup, teardown } from '@modtree/test-env'
 import { oneUp } from '@modtree/utils'
 import { container, getSource } from '@modtree/typeorm-config'
-import { ModuleRepository } from '../../src/Module'
 
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
 
-beforeAll(() =>
-  setup(db).then(() => {
-    Repo.Module = new ModuleRepository(db)
-  })
-)
+beforeAll(() => setup(db))
 afterAll(() => teardown(db))
-
-const lowerBound = 6100
 
 jest.setTimeout(60000)
 test('pull all modules from NUSMods', async () => {
@@ -24,7 +17,7 @@ test('pull all modules from NUSMods', async () => {
     Repo.Module!.pull().then((res) => {
       expect(res).toBeInstanceOf(Array)
       expect(res[0]).toBeInstanceOf(Module)
-      expect(res.length).toBeGreaterThan(lowerBound)
+      expect(res.length).toBeGreaterThan(6000)
     })
   )
 })

--- a/libs/repo-user/project.json
+++ b/libs/repo-user/project.json
@@ -31,5 +31,6 @@
       }
     }
   },
-  "tags": []
+  "tags": [],
+  "implicitDependencies": ["!test-env"]
 }

--- a/libs/repo-user/test/can-take-module.test.ts
+++ b/libs/repo-user/test/can-take-module.test.ts
@@ -1,21 +1,19 @@
 import { setup, teardown, Repo, t, init } from '@modtree/test-env'
 import { oneUp } from '@modtree/utils'
 import { getSource } from '@modtree/typeorm-config'
-import { UserRepository } from '../src'
 
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
 
 beforeAll(() =>
   setup(db)
-    .then(() => {
-      Repo.User = new UserRepository(db)
-      return Repo.User!.initialize({
+    .then(() =>
+      Repo.User!.initialize({
         ...init.user1,
         modulesDone: ['MA2001'],
         modulesDoing: ['MA2219'],
       })
-    })
+    )
     .then((user) => {
       t.user = user
     })

--- a/libs/repo-user/test/degree-methods.test.ts
+++ b/libs/repo-user/test/degree-methods.test.ts
@@ -2,22 +2,18 @@ import { Degree, User } from '@modtree/entity'
 import { oneUp } from '@modtree/utils'
 import { getSource } from '@modtree/typeorm-config'
 import { setup, teardown, Repo, t, init } from '@modtree/test-env'
-import { UserRepository } from '../src'
-import { DegreeRepository } from '@modtree/repo-degree'
 
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
 
 beforeAll(() =>
   setup(db)
-    .then(() => {
-      Repo.User = new UserRepository(db)
-      Repo.Degree = new DegreeRepository(db)
-      return Promise.all([
+    .then(() =>
+      Promise.all([
         Repo.User!.initialize(init.user1),
         Repo.Degree!.initialize(init.degree1),
       ])
-    })
+    )
     .then(([user, degree]) => {
       t.user = user
       t.degree = degree

--- a/libs/repo-user/test/get-eligible-modules.test.ts
+++ b/libs/repo-user/test/get-eligible-modules.test.ts
@@ -1,20 +1,18 @@
 import { setup, teardown, Repo, t, init } from '@modtree/test-env'
 import { flatten, oneUp } from '@modtree/utils'
 import { getSource } from '@modtree/typeorm-config'
-import { UserRepository } from '../src'
 
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
 
 beforeAll(() =>
   setup(db)
-    .then(() => {
-      Repo.User = new UserRepository(db)
-      return Repo.User!.initialize({
+    .then(() =>
+      Repo.User!.initialize({
         ...init.user1,
         modulesDone: ['CS1101S'],
       })
-    })
+    )
     .then((user) => {
       t.user = user
     })

--- a/libs/repo-user/test/get-unlocked-modules.test.ts
+++ b/libs/repo-user/test/get-unlocked-modules.test.ts
@@ -1,20 +1,18 @@
 import { setup, teardown, Repo, t, init } from '@modtree/test-env'
 import { flatten, oneUp } from '@modtree/utils'
 import { getSource } from '@modtree/typeorm-config'
-import { UserRepository } from '../src'
 import { User, Module } from '@modtree/entity'
 
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
 beforeAll(() =>
   setup(db)
-    .then(() => {
-      Repo.User = new UserRepository(db)
-      return Repo.User!.initialize({
+    .then(() =>
+      Repo.User!.initialize({
         ...init.user1,
         modulesDone: ['CS1010'],
       })
-    })
+    )
     .then((user) => {
       t.user = user
     })

--- a/libs/repo-user/test/has-taken-module.test.ts
+++ b/libs/repo-user/test/has-taken-module.test.ts
@@ -1,7 +1,6 @@
 import { setup, teardown, Repo, t, init } from '@modtree/test-env'
 import { oneUp } from '@modtree/utils'
 import { getSource } from '@modtree/typeorm-config'
-import { UserRepository } from '../src'
 import { User } from '@modtree/entity'
 
 const dbName = oneUp(__filename)
@@ -9,10 +8,7 @@ const db = getSource(dbName)
 
 beforeAll(() =>
   setup(db)
-    .then(() => {
-      Repo.User = new UserRepository(db)
-      return Repo.User!.initialize(init.user1)
-    })
+    .then(() => Repo.User!.initialize(init.user1))
     .then((user) => {
       t.user = user
     })

--- a/libs/repo-user/test/initialize.test.ts
+++ b/libs/repo-user/test/initialize.test.ts
@@ -2,16 +2,11 @@ import { User } from '@modtree/entity'
 import { setup, teardown, Repo, t, init } from '@modtree/test-env'
 import { oneUp } from '@modtree/utils'
 import { getSource } from '@modtree/typeorm-config'
-import { UserRepository } from '../src'
 
 const dbName = oneUp(__filename)
 const db = getSource(dbName)
 
-beforeAll(() =>
-  setup(db).then(() => {
-    Repo.User = new UserRepository(db)
-  })
-)
+beforeAll(() => setup(db))
 afterAll(() => teardown(db))
 
 it('initial count', async () => {

--- a/libs/repo-user/test/set-module-status.test.ts
+++ b/libs/repo-user/test/set-module-status.test.ts
@@ -1,7 +1,6 @@
 import { setup, teardown, Repo, t, init } from '@modtree/test-env'
 import { flatten, oneUp } from '@modtree/utils'
 import { getSource } from '@modtree/typeorm-config'
-import { UserRepository } from '../src'
 import { ModuleStatus } from '@modtree/types'
 import { User } from '@modtree/entity'
 
@@ -10,14 +9,13 @@ const db = getSource(dbName)
 
 beforeAll(() =>
   setup(db)
-    .then(() => {
-      Repo.User = new UserRepository(db)
-      return Repo.User!.initialize({
+    .then(() =>
+      Repo.User!.initialize({
         ...init.user1,
         modulesDone: ['MA2001'],
         modulesDoing: ['MA2219'],
       })
-    })
+    )
     .then((user) => {
       t.user = user
     })

--- a/libs/sql/project.json
+++ b/libs/sql/project.json
@@ -30,5 +30,6 @@
       }
     }
   },
-  "tags": []
+  "tags": [],
+  "implicitDependencies": ["!test-env"]
 }

--- a/libs/typeorm-config/project.json
+++ b/libs/typeorm-config/project.json
@@ -30,5 +30,6 @@
       }
     }
   },
-  "tags": []
+  "tags": [],
+  "implicitDependencies": ["!test-env"]
 }

--- a/libs/types/project.json
+++ b/libs/types/project.json
@@ -30,5 +30,6 @@
       }
     }
   },
-  "tags": []
+  "tags": [],
+  "implicitDependencies": ["!test-env"]
 }

--- a/libs/types/src/repository.ts
+++ b/libs/types/src/repository.ts
@@ -117,10 +117,10 @@ export interface IModuleCondensedRepository extends EModuleCondensed {
   findByCodes(moduleCodes: string[]): Promise<IModuleCondensed[]>
 }
 
-export type Repositories = Partial<{
-  Module: IModuleRepository
-  ModuleCondensed: IModuleCondensedRepository
-  User: IUserRepository
-  Degree: IDegreeRepository
-  Graph: IGraphRepository
-}>
+export type Repositories = {
+  Module?: IModuleRepository
+  ModuleCondensed?: IModuleCondensedRepository
+  User?: IUserRepository
+  Degree?: IDegreeRepository
+  Graph?: IGraphRepository
+}

--- a/libs/utils/project.json
+++ b/libs/utils/project.json
@@ -30,5 +30,6 @@
       }
     }
   },
-  "tags": []
+  "tags": [],
+  "implicitDependencies": ["!test-env"]
 }


### PR DESCRIPTION
### Summary of changes

- Deleting a degree now works, using `.remove()` instead of `.delete()`
- Deleting a degree now deletes associated graphs, but not associated users
- Added a test file that uses `.remove()`, to confirm that it cascades and deletes the right entities.

### Notes

- `.delete()` does not seem to work with cascade
- `.then()` seems to be swallowing TypeORM errors

### Testing

`yarn nx run repo-degree:test`
