### PR TITLE
refactor(api): use PATCH instead of POST where appropriate

### DIFF
--- a/apps/docs/data/graph/flow.ts
+++ b/apps/docs/data/graph/flow.ts
@@ -40,11 +40,11 @@ const fulfilled = {
 }
 
 export const flow: MethodProps = {
-  method: 'Update frontend props',
+  method: 'Update flow props',
   description:
-    'This endpoint updates frontend-related props. This includes moving a node.',
-  endpoint: '/graphs/{graphId}/update-frontend',
-  requestType: 'POST',
+    'This endpoint updates React Flow props. This includes moving a node.',
+  endpoint: '/graphs/{graphId}/flow',
+  requestType: 'PATCH',
   parameters: {
     pathParams: [
       {

--- a/apps/docs/data/graph/toggle.ts
+++ b/apps/docs/data/graph/toggle.ts
@@ -43,7 +43,7 @@ export const toggle: MethodProps = {
   method: 'Toggle a module',
   description: 'Toggle the visibility of a module in a graph',
   endpoint: '/graphs/{graphId}/toggle/{moduleCode}',
-  requestType: 'POST',
+  requestType: 'PATCH',
   parameters: {
     pathParams: [
       {

--- a/apps/docs/data/user/insert-degrees.ts
+++ b/apps/docs/data/user/insert-degrees.ts
@@ -19,7 +19,7 @@ export const insertDegrees: MethodProps = {
   method: 'Insert degrees',
   description: 'Adds degrees to a user',
   endpoint: '/users/{userId}/degrees',
-  requestType: 'POST',
+  requestType: 'PATCH',
   parameters: {
     pathParams: [
       {

--- a/apps/docs/types.d.ts
+++ b/apps/docs/types.d.ts
@@ -1,6 +1,6 @@
 type CustomError = 'Not found' | 'Database Error'
 
-type RequestType = 'POST' | 'GET' | 'DELETE'
+type RequestType = 'POST' | 'GET' | 'DELETE' | 'PATCH'
 
 type Data = string | number | string[] | number[] | Record<string, any>
 

--- a/apps/server/src/routes.ts
+++ b/apps/server/src/routes.ts
@@ -135,7 +135,7 @@ export const routes: Route[] = [
     ],
   },
   {
-    method: 'post',
+    method: 'patch',
     route: '/graphs/:graphId/flow',
     fn: GraphApi.updateFrontendProps,
     validators: [body('flowNodes').isArray(), body('flowEdges').isArray()],

--- a/apps/server/src/routes.ts
+++ b/apps/server/src/routes.ts
@@ -54,7 +54,7 @@ export const routes: Route[] = [
     ],
   },
   {
-    method: 'post',
+    method: 'patch',
     route: '/users/:userId/degrees',
     fn: UserApi.insertDegrees,
     validators: [body('degreeIds').isArray().notEmpty()],

--- a/apps/server/src/routes.ts
+++ b/apps/server/src/routes.ts
@@ -125,7 +125,7 @@ export const routes: Route[] = [
     validators: [],
   },
   {
-    method: 'post',
+    method: 'patch',
     route: '/graphs/:graphId/toggle/:moduleCode',
     fn: GraphApi.toggle,
     validators: [

--- a/apps/server/test/graphs/:graphId/flow/[PATCH].test.ts
+++ b/apps/server/test/graphs/:graphId/flow/[PATCH].test.ts
@@ -26,7 +26,7 @@ afterAll(() => teardown(db))
 // 017fc011-486c-4ec6-a038-9a92ab85a8f3
 
 const testRequest = async () =>
-  request(app).post('/graphs/017fc011-486c-4ec6-a038-9a92ab85a8f3/flow').send({
+  request(app).patch('/graphs/017fc011-486c-4ec6-a038-9a92ab85a8f3/flow').send({
     flowNodes: [],
     flowEdges: [],
   })
@@ -44,7 +44,7 @@ test('`findOneById` is called with correct args', async () => {
 })
 
 const badRequest = async () =>
-  request(app).post('/graphs/017fc011-486c-4ec6-a038-9a92ab85a8f3/flow').send({
+  request(app).patch('/graphs/017fc011-486c-4ec6-a038-9a92ab85a8f3/flow').send({
     flowNodes: 'NOT_VALID', // supposed to be array
     flowEdges: 'NOT_VALID', // supposed to be array
   })

--- a/apps/server/test/graphs/:graphId/toggle/:moduleCode/[PATCH].test.ts
+++ b/apps/server/test/graphs/:graphId/toggle/:moduleCode/[PATCH].test.ts
@@ -26,7 +26,7 @@ afterAll(() => teardown(db))
 // 017fc011-486c-4ec6-a038-9a92ab85a8f3
 
 const testRequest = async () =>
-  request(app).post(
+  request(app).patch(
     '/graphs/017fc011-486c-4ec6-a038-9a92ab85a8f3/toggle/MA1100'
   )
 
@@ -43,7 +43,7 @@ test('`findOneById` is called with correct args', async () => {
 })
 
 const badRequest = async () =>
-  request(app).post(
+  request(app).patch(
     '/graphs/017fc011-486c-4ec6-a038-9a92ab85a8f3/toggle/NOT_VALID'
   )
 

--- a/apps/server/test/users/:userId/degrees/[PATCH].test.ts
+++ b/apps/server/test/users/:userId/degrees/[PATCH].test.ts
@@ -26,7 +26,7 @@ afterAll(() => teardown(db))
 
 async function testRequest() {
   await request(app)
-    .post('/users/924a4c06-4ccb-4208-8791-ecae4099a763/degrees')
+    .patch('/users/924a4c06-4ccb-4208-8791-ecae4099a763/degrees')
     .send({ degreeIds: ['a', 'b'] })
 }
 

--- a/libs/postman/package.json
+++ b/libs/postman/package.json
@@ -11,7 +11,7 @@
     "users:list": "yarn ts ./dist/users/list.js",
     "users:create": "yarn ts ./dist/users/create.js",
     "users:delete": "yarn ts ./dist/users/delete.js",
-    "users:insert-degrees": "yarn ts ./dist/users/insert-degree.js",
+    "users:insert-degrees": "yarn ts ./dist/users/insert-degrees.js",
     "degrees:create": "yarn ts ./dist/degrees/create.js",
     "degrees:list": "yarn ts ./dist/degrees/list.js",
     "degrees:delete": "yarn ts ./dist/degrees/delete.js",

--- a/libs/postman/postman.ts
+++ b/libs/postman/postman.ts
@@ -49,6 +49,9 @@ export class postman {
   static post(endpoint: string, params?: any) {
     return verbosify(() => axios.post(postman.url + endpoint, params))
   }
+  static patch(endpoint: string, params?: any) {
+    return verbosify(() => axios.patch(postman.url + endpoint, params))
+  }
   static delete(endpoint: string, params?: any) {
     return verbosify(() => axios.delete(postman.url + endpoint, params))
   }

--- a/libs/postman/users/insert-degrees.ts
+++ b/libs/postman/users/insert-degrees.ts
@@ -2,11 +2,11 @@ import { postman } from '../postman'
 
 const user = {
   id: 'e9f66c30-c96f-4ebd-b771-99ae8646f438',
-  savedDegrees: ['f2b8d3e1-1907-4d60-82ee-cef57b510b9e'],
+  savedDegrees: ['e8bb5bf7-3f7d-4853-828f-952c99344241'],
 }
 
 postman
-  .post(`users/${user.id}/degrees`, {
+  .patch(`users/${user.id}/degrees`, {
     degreeIds: user.savedDegrees,
   })
   .then(console.log)


### PR DESCRIPTION
### Summary of changes

- `POST` is now used only for user login, and entity creation
- `PATCH` is used for updates to existing entities, where the client only specifies a partial entity.

### Testing

- Server tests
- Frontend should not be affected
