### PR TITLE
refactor: module repo methods

### DIFF
--- a/.github/workflows/ci-no-cache.yml
+++ b/.github/workflows/ci-no-cache.yml
@@ -35,9 +35,6 @@ jobs:
       - name: Start PostgreSQL
         run: ./.github/scripts/postgres.sh
 
-      - name: 📦 Load database environment
-        run: ${{ env.PREFIX }} yarn nx test test-env --skip-nx-cache
-
       - name: 📦 Run tests for ${{ matrix.project }}
         run: ${{ env.PREFIX }} yarn nx test ${{ matrix.project }} --coverage --skip-nx-cache
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,6 @@ jobs:
         run: ./.github/scripts/postgres.sh
 
       - name: 📦 Run tests for ${{ matrix.project }}
-        id: yarn_test
         run: ${{ env.PREFIX }} yarn nx test ${{ matrix.project }} --coverage
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: ./.github/scripts/postgres.sh
 
       - name: 📦 Run tests for ${{ matrix.project }}
-        run: ${{ env.PREFIX }} yarn nx test ${{ matrix.project }} --coverage
+        run: ${{ env.PREFIX }} yarn nx test ${{ matrix.project }} --coverage --runInBand
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/apps/server/jest.config.ts
+++ b/apps/server/jest.config.ts
@@ -13,6 +13,5 @@ export default {
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../coverage/apps/server',
-  testPathIgnorePatterns: ['test_backup'],
   maxWorkers: 1,
 }

--- a/libs/repo-api/test/user-login.test.ts
+++ b/libs/repo-api/test/user-login.test.ts
@@ -29,7 +29,7 @@ it('returns a user', async () => {
 })
 
 it('user id exists in database', async () => {
-  await Repo.User!.findOneByAuthZeroId(initializedUser.authZeroId).then((u) => {
+  await Repo.User.findOneByAuthZeroId(initializedUser.authZeroId).then((u) => {
     expect(u.id).toStrictEqual(initializedUser.id)
     retrievedUser = u
   })

--- a/libs/repo-base/src/delete-all.spec.ts
+++ b/libs/repo-base/src/delete-all.spec.ts
@@ -9,14 +9,14 @@ beforeAll(() => setup(db))
 afterAll(() => teardown(db))
 
 test('there are modules', async () => {
-  await Repo.Module!.count().then((count) => {
+  await Repo.Module.count().then((count) => {
     expect(count).toBeGreaterThan(0)
   })
 })
 
 test('deletes all', async () => {
-  await Repo.Module!.deleteAll()
-    .then(() => Repo.Module!.count())
+  await Repo.Module.deleteAll()
+    .then(() => Repo.Module.count())
     .then((count) => {
       expect(count).toEqual(0)
     })

--- a/libs/repo-base/src/find-by-key.spec.ts
+++ b/libs/repo-base/src/find-by-key.spec.ts
@@ -11,7 +11,7 @@ beforeAll(() => setup(db))
 afterAll(() => teardown(db))
 
 test('grab an id', async () => {
-  await Repo.Module!.find({ take: 1 }).then((module) => {
+  await Repo.Module.find({ take: 1 }).then((module) => {
     expect(typeof module[0].id).toBe('string')
     id = module[0].id
     title = module[0].title
@@ -19,7 +19,7 @@ test('grab an id', async () => {
 })
 
 test('retrieves correct title', async () => {
-  await Repo.Module!.findOneById(id).then((module) => {
+  await Repo.Module.findOneById(id).then((module) => {
     expect(module.title).toEqual(title)
   })
 })

--- a/libs/repo-base/src/get-relation-names.spec.ts
+++ b/libs/repo-base/src/get-relation-names.spec.ts
@@ -39,31 +39,31 @@ const expectedRelations = {
 }
 
 test('User has correct relations', () => {
-  const received = getRelationNames(Repo.User!)
+  const received = getRelationNames(Repo.User)
   const expected = expectedRelations.User
   expect(received).toStrictEqual(expected)
 })
 
 test('Degree has correct relations', () => {
-  const received = getRelationNames(Repo.Degree!)
+  const received = getRelationNames(Repo.Degree)
   const expected = expectedRelations.Degree
   expect(received).toStrictEqual(expected)
 })
 
 test('Graph has correct relations', () => {
-  const received = getRelationNames(Repo.Graph!)
+  const received = getRelationNames(Repo.Graph)
   const expected = expectedRelations.Graph
   expect(received).toStrictEqual(expected)
 })
 
 test('Module has correct relations', () => {
-  const received = getRelationNames(Repo.Module!)
+  const received = getRelationNames(Repo.Module)
   const expected = expectedRelations.Module
   expect(received).toStrictEqual(expected)
 })
 
 test('ModuleCondensed has correct relations', () => {
-  const received = getRelationNames(Repo.ModuleCondensed!)
+  const received = getRelationNames(Repo.ModuleCondensed)
   const expected = expectedRelations.ModuleCondensed
   expect(received).toStrictEqual(expected)
 })

--- a/libs/repo-degree/test/delete.test.ts
+++ b/libs/repo-degree/test/delete.test.ts
@@ -10,17 +10,17 @@ beforeAll(() =>
   setup(db)
     .then(() => {
       return Promise.all([
-        Repo.User!.initialize(init.user1),
-        Repo.Degree!.initialize(init.degree1),
+        Repo.User.initialize(init.user1),
+        Repo.Degree.initialize(init.degree1),
       ])
     })
     .then(([user, degree]) => {
       t.user = user
       t.degree = degree
-      return Repo.User!.insertDegrees(t.user, [t.degree.id])
+      return Repo.User.insertDegrees(t.user, [t.degree.id])
     })
     .then(() =>
-      Repo.Graph!.initialize({
+      Repo.Graph.initialize({
         userId: t.user!.id,
         degreeId: t.degree!.id,
         modulesPlacedCodes: [],
@@ -35,37 +35,35 @@ beforeAll(() =>
 afterAll(() => teardown(db))
 
 it('user has 1 degree', async () => {
-  await Repo.User!.findOneById(t.user!.id).then((user) => {
+  await Repo.User.findOneById(t.user!.id).then((user) => {
     expect(user.savedDegrees).toHaveLength(1)
   })
 })
 
 it('successfully deletes degree', async () => {
-  await Repo.Degree!.remove(t.degree!).then((degree) => {
+  await Repo.Degree.remove(t.degree!).then((degree) => {
     expect(degree.id).toEqual(undefined)
   })
 })
 
 it('degree does not exist', async () => {
-  await expect(() => Repo.Degree!.findOneById(t.degree!.id)).rejects.toThrow(
+  await expect(() => Repo.Degree.findOneById(t.degree!.id)).rejects.toThrow(
     Error
   )
 })
 
 it('user exists', async () => {
-  await Repo.User!.findOneById(t.user!.id).then((user) => {
+  await Repo.User.findOneById(t.user!.id).then((user) => {
     expect(user).toBeInstanceOf(User)
   })
 })
 
 it('user has 0 degrees', async () => {
-  await Repo.User!.findOneById(t.user!.id).then((user) => {
+  await Repo.User.findOneById(t.user!.id).then((user) => {
     expect(user.savedDegrees).toHaveLength(0)
   })
 })
 
 it('graph does not exist', async () => {
-  await expect(() => Repo.Graph!.findOneById(t.graph!.id)).rejects.toThrow(
-    Error
-  )
+  await expect(() => Repo.Graph.findOneById(t.graph!.id)).rejects.toThrow(Error)
 })

--- a/libs/repo-degree/test/initialize.test.ts
+++ b/libs/repo-degree/test/initialize.test.ts
@@ -25,20 +25,20 @@ const props = {
 }
 
 it('initial count', async () => {
-  await Repo.Degree!.count().then((count) => {
+  await Repo.Degree.count().then((count) => {
     expect(count).toEqual(0)
   })
 })
 
 it('returns a degree', async () => {
-  await Repo.Degree!.initialize(props).then((res) => {
+  await Repo.Degree.initialize(props).then((res) => {
     expect(res).toBeInstanceOf(Degree)
     t.degree = res
   })
 })
 
 it('increments the count by 1', async () => {
-  await Repo.Degree!.count().then((count) => {
+  await Repo.Degree.count().then((count) => {
     expect(count).toEqual(1)
   })
 })

--- a/libs/repo-degree/test/insert-modules.test.ts
+++ b/libs/repo-degree/test/insert-modules.test.ts
@@ -9,7 +9,7 @@ const db = getSource(dbName)
 beforeAll(() =>
   setup(db)
     .then(() =>
-      Repo.Degree!.initialize({
+      Repo.Degree.initialize({
         moduleCodes: [],
         title: 'Test Degree',
       })
@@ -22,7 +22,7 @@ beforeAll(() =>
 afterAll(() => teardown(db))
 
 async function insertModules(degree: Degree, moduleCodes: string[]) {
-  return Repo.Degree!.insertModules(degree, moduleCodes)
+  return Repo.Degree.insertModules(degree, moduleCodes)
 }
 
 it('correctly saves modules', async () => {

--- a/libs/repo-graph/test/get-suggest-modules-params.test.ts
+++ b/libs/repo-graph/test/get-suggest-modules-params.test.ts
@@ -32,13 +32,13 @@ beforeAll(() =>
   setup(db)
     .then(() =>
       Promise.all([
-        Repo.User!.initialize(userProps),
-        Repo.Degree!.initialize(degreeProps),
+        Repo.User.initialize(userProps),
+        Repo.Degree.initialize(degreeProps),
       ])
     )
     .then(([user, degree]) => {
       t.user = user
-      return Repo.Graph!.initialize({
+      return Repo.Graph.initialize({
         userId: user.id,
         degreeId: degree.id,
         modulesPlacedCodes: [],
@@ -53,13 +53,11 @@ beforeAll(() =>
 afterAll(() => teardown(db))
 
 it('returns an array of arrays', async () => {
-  await Repo.Graph!.getSuggestModulesParams(t.graph!, ['CM1102']).then(
-    (res) => {
-      expect(res).toBeArrayOf(Array)
-      // res.forEach((e) => expect(typeof e).toBe('string'))
-      t.arrayOfArrays = res
-    }
-  )
+  await Repo.Graph.getSuggestModulesParams(t.graph!, ['CM1102']).then((res) => {
+    expect(res).toBeArrayOf(Array)
+    // res.forEach((e) => expect(typeof e).toBe('string'))
+    t.arrayOfArrays = res
+  })
 })
 
 it('the array has length of 4', () => {

--- a/libs/repo-graph/test/initialize/no-pull-all.test.ts
+++ b/libs/repo-graph/test/initialize/no-pull-all.test.ts
@@ -9,8 +9,8 @@ beforeAll(() =>
   setup(db)
     .then(() =>
       Promise.all([
-        Repo.User!.initialize(init.user1),
-        Repo.Degree!.initialize(init.degree1),
+        Repo.User.initialize(init.user1),
+        Repo.Degree.initialize(init.degree1),
       ])
     )
     .then(([user, degree]) => {
@@ -21,7 +21,7 @@ beforeAll(() =>
 afterAll(() => teardown(db))
 
 it('no placed nor hidden', async () => {
-  await Repo.Graph!.initialize({
+  await Repo.Graph.initialize({
     userId: t.user!.id,
     degreeId: t.degree!.id,
     modulesPlacedCodes: [],

--- a/libs/repo-graph/test/initialize/pull-all.test.ts
+++ b/libs/repo-graph/test/initialize/pull-all.test.ts
@@ -10,12 +10,12 @@ beforeAll(() =>
   setup(db)
     .then(() =>
       Promise.all([
-        Repo.User!.initialize({
+        Repo.User.initialize({
           ...init.user1,
           modulesDone: ['MA2001'],
           modulesDoing: ['MA2219'],
         }),
-        Repo.Degree!.initialize({
+        Repo.Degree.initialize({
           moduleCodes: ['CS1101S', 'MA2001'],
           title: 'Test Degree',
         }),
@@ -29,13 +29,13 @@ beforeAll(() =>
 afterAll(() => teardown(db))
 
 it('initial count', async () => {
-  await Repo.Graph!.count().then((count) => {
+  await Repo.Graph.count().then((count) => {
     expect(count).toEqual(0)
   })
 })
 
 it('returns a graph', async () => {
-  await Repo.Graph!.initialize({
+  await Repo.Graph.initialize({
     userId: t.user!.id,
     degreeId: t.degree!.id,
     modulesPlacedCodes: [],
@@ -48,7 +48,7 @@ it('returns a graph', async () => {
 })
 
 it('increments the count by 1', async () => {
-  await Repo.Graph!.count().then((count) => {
+  await Repo.Graph.count().then((count) => {
     expect(count).toEqual(1)
   })
 })

--- a/libs/repo-graph/test/toggle.test.ts
+++ b/libs/repo-graph/test/toggle.test.ts
@@ -11,12 +11,12 @@ beforeAll(() =>
   setup(db)
     .then(() =>
       Promise.all([
-        Repo.User!.initialize(init.user1),
-        Repo.Degree!.initialize(init.degree1),
+        Repo.User.initialize(init.user1),
+        Repo.Degree.initialize(init.degree1),
       ])
     )
     .then(([user, degree]) =>
-      Repo.Graph!.initialize({
+      Repo.Graph.initialize({
         userId: user.id,
         degreeId: degree.id,
         modulesPlacedCodes: ['CM1501'],
@@ -31,11 +31,11 @@ beforeAll(() =>
 afterAll(() => teardown(db))
 
 async function findGraph(id: string) {
-  return Repo.Graph!.findOneById(id)
+  return Repo.Graph.findOneById(id)
 }
 
 async function toggle(graph: Graph, moduleCode: string) {
-  return Repo.Graph!.toggleModule(graph, moduleCode)
+  return Repo.Graph.toggleModule(graph, moduleCode)
 }
 
 test('MA2001 is hidden', async () => {
@@ -107,7 +107,7 @@ test('EE1111A becomes placed', async () => {
 
 test('CS420BZT is not in database', async () => {
   await expect(() =>
-    Repo.ModuleCondensed!.findOneByOrFail({ moduleCode: 'CS420BZT' })
+    Repo.ModuleCondensed.findOneByOrFail({ moduleCode: 'CS420BZT' })
   ).rejects.toThrowError(
     new EntityNotFoundError(ModuleCondensed, {
       moduleCode: 'CS420BZT',
@@ -117,7 +117,7 @@ test('CS420BZT is not in database', async () => {
 
 test('error on toggling CS420BZT', async () => {
   await expect(() =>
-    Repo.Graph!.toggleModule(t.graph!, 'CS420BZT')
+    Repo.Graph.toggleModule(t.graph!, 'CS420BZT')
   ).rejects.toThrowError(
     new EntityNotFoundError(Module, {
       moduleCode: 'CS420BZT',

--- a/libs/repo-graph/test/update-frontend-props.test.ts
+++ b/libs/repo-graph/test/update-frontend-props.test.ts
@@ -12,12 +12,12 @@ beforeAll(() =>
   setup(db)
     .then(() =>
       Promise.all([
-        Repo.User!.initialize(init.user1),
-        Repo.Degree!.initialize(init.degree1),
+        Repo.User.initialize(init.user1),
+        Repo.Degree.initialize(init.degree1),
       ])
     )
     .then(([user, degree]) =>
-      Repo.Graph!.initialize({
+      Repo.Graph.initialize({
         userId: user.id,
         degreeId: degree.id,
         modulesPlacedCodes: [],
@@ -32,11 +32,11 @@ beforeAll(() =>
 afterAll(() => teardown(db))
 
 async function findGraph(id: string) {
-  return Repo.Graph!.findOneById(id)
+  return Repo.Graph.findOneById(id)
 }
 
 async function updateFrontendProps(props: GraphFrontendProps) {
-  return Repo.Graph!.updateFrontendProps(t.graph!, props)
+  return Repo.Graph.updateFrontendProps(t.graph!, props)
 }
 
 it('returns a relationless graph', async () => {

--- a/libs/repo-module/src/Module.ts
+++ b/libs/repo-module/src/Module.ts
@@ -195,31 +195,45 @@ export class ModuleRepository
     requiredModules: string[]
   ): Promise<string[]> {
     const modules = unique(modulesDone.concat(modulesSelected))
-    // get relevant modules
-    const postReqs = await this.getPostReqs(modules)
-    const eligibleModules = await this.getEligibleModules(
-      modulesDone,
-      modulesDoing,
-      modulesSelected
+    /**
+     * get module codes of modules that are eligible for,
+     * that are also within the post-requisites
+     */
+    const filtered = Promise.all([
+      this.getPostReqs(modules),
+      this.getEligibleModules(modulesDone, modulesDoing, modulesSelected),
+    ]).then(([postReqs, eligible]) =>
+      eligible.filter((code) => postReqs.includes(code))
     )
-    const filtered = eligibleModules.filter((one) => postReqs.includes(one))
-    // obtain data for sorting criteria
-    const resolvedPromises = await Promise.all(
-      filtered.map((moduleCode) =>
-        this.getUnlockedModules(modulesDone, modulesDoing, moduleCode)
+
+    /**
+     * get a count of how many modules a doing a particular module unlocks
+     */
+    const unlockedModuleCounts = filtered
+      .then((filtered) =>
+        Promise.all(
+          filtered.map((code) =>
+            this.getUnlockedModules(modulesDone, modulesDoing, code)
+          )
+        )
       )
-    )
-    const unlockedModuleCounts = resolvedPromises.map((one) =>
-      one instanceof Array ? one.length : 0
-    )
-    // -- data processing
-    const data = filtered.map(
-      (moduleCode, origIdx): Data => ({
-        moduleCode,
-        inDegree: requiredModules.includes(moduleCode),
-        numUnlockedModules: unlockedModuleCounts[origIdx],
-        origIdx,
-      })
+      .then((unlocked) =>
+        unlocked.map((codes) => (Array.isArray(codes) ? codes.length : 0))
+      )
+
+    /**
+     * consolidate data used for ranking later
+     */
+    const data = Promise.all([filtered, unlockedModuleCounts]).then(
+      ([filtered, unlockedModuleCounts]) =>
+        filtered.map(
+          (moduleCode, origIdx): Data => ({
+            moduleCode,
+            inDegree: requiredModules.includes(moduleCode),
+            numUnlockedModules: unlockedModuleCounts[origIdx],
+            origIdx,
+          })
+        )
     )
 
     /**
@@ -240,9 +254,11 @@ export class ModuleRepository
       return a.moduleCode < b.moduleCode ? -1 : 1
     }
 
-    // Sort and rebuild original array
-    data.sort(cmp)
-    const final = data.map((one) => filtered[one.origIdx])
-    return final
+    const sorted = Promise.all([data, filtered]).then(([data, filtered]) => {
+      data.sort(cmp)
+      return data.map((module) => filtered[module.origIdx])
+    })
+
+    return sorted
   }
 }

--- a/libs/repo-module/src/Module.ts
+++ b/libs/repo-module/src/Module.ts
@@ -164,23 +164,15 @@ export class ModuleRepository
     const addedModuleCodes = [moduleCode]
     // 1. Return empty array if module in modulesDone or modulesDoing
     if (hasTakenModule(modulesDone, modulesDoing, moduleCode)) return []
-    // 2. Get current eligible modules
-    const eligibleModules = await this.getEligibleModules(
-      modulesDone,
-      modulesDoing,
-      []
+    return Promise.all([
+      // 2. Get current eligible modules
+      this.getEligibleModules(modulesDone, modulesDoing, []),
+      // 3. Get unlocked eligible modules
+      this.getEligibleModules(modulesDone, modulesDoing, addedModuleCodes),
+    ]).then(([eligible, unlocked]) =>
+      // 4. Compare unlockedModules to eligibleModules
+      unlocked.filter((code) => !eligible.includes(code))
     )
-    // 3. Get unlocked eligible modules
-    const unlockedModules = await this.getEligibleModules(
-      modulesDone,
-      modulesDoing,
-      addedModuleCodes
-    )
-    // 4. Compare unlockedModules to eligibleModules
-    const filtered = unlockedModules.filter(
-      (moduleCode) => !eligibleModules.includes(moduleCode)
-    )
-    return filtered
   }
 
   /**

--- a/libs/repo-module/src/utils/check-tree.spec.ts
+++ b/libs/repo-module/src/utils/check-tree.spec.ts
@@ -6,7 +6,7 @@ beforeAll(() => setup(db, { restore: false }))
 afterAll(() => teardown(db))
 
 it('true for mods without pre-reqs', async () => {
-  await Repo.Module!.findByCodes(['CS1010', 'MA1301', 'EL1101E']).then(
+  await Repo.Module.findByCodes(['CS1010', 'MA1301', 'EL1101E']).then(
     (modules) => {
       modules.forEach((module) => {
         expect(checkTree(module.prereqTree, [])).toEqual(true)
@@ -16,7 +16,7 @@ it('true for mods without pre-reqs', async () => {
 })
 
 it('true if pre-reqs are cleared', async () => {
-  await Repo.Module!.findOneByOrFail({
+  await Repo.Module.findOneByOrFail({
     moduleCode: 'CS2040S',
   }).then((module) => {
     expect(checkTree(module.prereqTree, ['CS1231', 'CS1010'])).toEqual(true)
@@ -24,7 +24,7 @@ it('true if pre-reqs are cleared', async () => {
 })
 
 it("false if pre-reqs aren't cleared", async () => {
-  await Repo.Module!.findOneByOrFail({
+  await Repo.Module.findOneByOrFail({
     moduleCode: 'CS2040S',
   }).then((module) => {
     expect(checkTree(module.prereqTree, [])).toEqual(false)

--- a/libs/repo-module/test/json-dump.test.ts
+++ b/libs/repo-module/test/json-dump.test.ts
@@ -13,8 +13,8 @@ let moduleCondensedRepo: IModuleCondensedRepository
 
 beforeAll(() =>
   setup(db).then(() => {
-    moduleRepo = Repo.Module!
-    moduleCondensedRepo = Repo.ModuleCondensed!
+    moduleRepo = Repo.Module
+    moduleCondensedRepo = Repo.ModuleCondensed
   })
 )
 afterAll(() => teardown(db))

--- a/libs/repo-module/test/json-dump.test.ts
+++ b/libs/repo-module/test/json-dump.test.ts
@@ -1,49 +1,51 @@
-import { Module, ModuleCondensed } from '@modtree/entity'
-import { Repo, setup, teardown } from '@modtree/test-env'
-import { getSource } from '@modtree/typeorm-config'
-import { IModuleCondensedRepository, IModuleRepository } from '@modtree/types'
-import { oneUp } from '@modtree/utils'
-import fs from 'fs'
-import { join } from 'path'
+expect('this').not.toBe('commented')
 
-const dbName = oneUp(__filename)
-const db = getSource(dbName)
-let moduleRepo: IModuleRepository
-let moduleCondensedRepo: IModuleCondensedRepository
-
-beforeAll(() =>
-  setup(db).then(() => {
-    moduleRepo = Repo.Module
-    moduleCondensedRepo = Repo.ModuleCondensed
-  })
-)
-afterAll(() => teardown(db))
-
-describe('modules', () => {
-  let modules: Module[]
-  it('gets all module info', async () => {
-    await moduleRepo.find().then((res) => {
-      modules = res
-      expect(res).toBeArrayOf(Module)
-    })
-    fs.writeFileSync(join(__dirname, 'modules.json'), JSON.stringify(modules))
-  })
-})
-
-describe('modules condensed', () => {
-  let modules: ModuleCondensed[]
-  it('gets all module info', async () => {
-    await moduleCondensedRepo.find().then((res) => {
-      modules = res
-      expect(res).toBeArrayOf(ModuleCondensed)
-    })
-    fs.writeFileSync(
-      join(__dirname, 'modules-condensed.json'),
-      JSON.stringify(modules)
-    )
-    fs.writeFileSync(
-      join(__dirname, 'module-codes.json'),
-      JSON.stringify(modules.map((m) => m.moduleCode))
-    )
-  })
-})
+// import { Module, ModuleCondensed } from '@modtree/entity'
+// import { Repo, setup, teardown } from '@modtree/test-env'
+// import { getSource } from '@modtree/typeorm-config'
+// import { IModuleCondensedRepository, IModuleRepository } from '@modtree/types'
+// import { oneUp } from '@modtree/utils'
+// import fs from 'fs'
+// import { join } from 'path'
+//
+// const dbName = oneUp(__filename)
+// const db = getSource(dbName)
+// let moduleRepo: IModuleRepository
+// let moduleCondensedRepo: IModuleCondensedRepository
+//
+// beforeAll(() =>
+//   setup(db).then(() => {
+//     moduleRepo = Repo.Module
+//     moduleCondensedRepo = Repo.ModuleCondensed
+//   })
+// )
+// afterAll(() => teardown(db))
+//
+// describe('modules', () => {
+//   let modules: Module[]
+//   it('gets all module info', async () => {
+//     await moduleRepo.find().then((res) => {
+//       modules = res
+//       expect(res).toBeArrayOf(Module)
+//     })
+//     fs.writeFileSync(join(__dirname, 'modules.json'), JSON.stringify(modules))
+//   })
+// })
+//
+// describe('modules condensed', () => {
+//   let modules: ModuleCondensed[]
+//   it('gets all module info', async () => {
+//     await moduleCondensedRepo.find().then((res) => {
+//       modules = res
+//       expect(res).toBeArrayOf(ModuleCondensed)
+//     })
+//     fs.writeFileSync(
+//       join(__dirname, 'modules-condensed.json'),
+//       JSON.stringify(modules)
+//     )
+//     fs.writeFileSync(
+//       join(__dirname, 'module-codes.json'),
+//       JSON.stringify(modules.map((m) => m.moduleCode))
+//     )
+//   })
+// })

--- a/libs/repo-module/test/module-condensed/find-by-codes.test.ts
+++ b/libs/repo-module/test/module-condensed/find-by-codes.test.ts
@@ -7,7 +7,7 @@ beforeAll(() => setup(db, { restore: false }))
 afterAll(() => teardown(db))
 
 async function findByCodes(moduleCodes: string[]) {
-  return Repo.ModuleCondensed!.findByCodes(moduleCodes)
+  return Repo.ModuleCondensed.findByCodes(moduleCodes)
 }
 
 it('returns an array of condensed modules', async () => {

--- a/libs/repo-module/test/module-condensed/get-codes.test.ts
+++ b/libs/repo-module/test/module-condensed/get-codes.test.ts
@@ -5,7 +5,7 @@ beforeAll(() => setup(db, { restore: false }))
 afterAll(() => teardown(db))
 
 test('returns an array of strings', async () => {
-  await Repo.ModuleCondensed!.getCodes().then((codes) => {
+  await Repo.ModuleCondensed.getCodes().then((codes) => {
     codes.forEach((e) => expect(typeof e).toBe('string'))
     expect(codes.length).toBeGreaterThan(6000)
   })

--- a/libs/repo-module/test/module-condensed/initialize.test.ts
+++ b/libs/repo-module/test/module-condensed/initialize.test.ts
@@ -15,21 +15,21 @@ beforeAll(() => setup(db))
 afterAll(() => teardown(db))
 
 it('initial count', async () => {
-  await Repo.ModuleCondensed!.count().then((c) => {
+  await Repo.ModuleCondensed.count().then((c) => {
     expect(c).toBeGreaterThan(6000)
     count = c
   })
 })
 
 it('returns a module', async () => {
-  await Repo.ModuleCondensed!.initialize(m).then((res) => {
+  await Repo.ModuleCondensed.initialize(m).then((res) => {
     expect(res).toBeInstanceOf(ModuleCondensed)
     t.modulesCondensed = [res]
   })
 })
 
 it('increments the count by 1', async () => {
-  await Repo.ModuleCondensed!.count().then((c) => {
+  await Repo.ModuleCondensed.count().then((c) => {
     expect(c).toEqual(count + 1)
   })
 })

--- a/libs/repo-module/test/module/can-take-module.test.ts
+++ b/libs/repo-module/test/module/can-take-module.test.ts
@@ -5,7 +5,7 @@ beforeAll(() => setup(db, { restore: false }))
 afterAll(() => teardown(db))
 
 async function canTakeModule(done: string[], doing: string[], query: string) {
-  return Repo.Module!.canTakeModule(done, doing, query)
+  return Repo.Module.canTakeModule(done, doing, query)
 }
 
 it('returns correct results', async () => {

--- a/libs/repo-module/test/module/check-health/count.test.ts
+++ b/libs/repo-module/test/module/check-health/count.test.ts
@@ -13,8 +13,8 @@ let condensed: ModuleCondensed[]
 beforeAll(() =>
   setup(db, { restore: false }).then(() =>
     Promise.all([
-      Repo.ModuleCondensed!.findAndCount(),
-      Repo.Module!.findAndCount(),
+      Repo.ModuleCondensed.findAndCount(),
+      Repo.Module.findAndCount(),
     ]).then((res) => {
       count.condensed = res[0][1]
       count.modules = res[1][1]

--- a/libs/repo-module/test/module/check-health/json.test.ts
+++ b/libs/repo-module/test/module/check-health/json.test.ts
@@ -9,7 +9,7 @@ const notInDb = new Set<string>()
 
 beforeAll(() =>
   setup(db, { restore: false })
-    .then(() => Repo.Module!.find())
+    .then(() => Repo.Module.find())
     .then((res) => {
       modules = res.filter((m) => typeof m.prereqTree !== 'string')
     })

--- a/libs/repo-module/test/module/check-health/string.test.ts
+++ b/libs/repo-module/test/module/check-health/string.test.ts
@@ -9,7 +9,7 @@ let modules: Module[]
 
 beforeAll(() =>
   setup(db, { restore: false })
-    .then(() => Repo.Module!.find())
+    .then(() => Repo.Module.find())
     .then((res) => {
       modules = res.filter((m) => typeof m.prereqTree === 'string')
     })

--- a/libs/repo-module/test/module/find-by-faculty.test.ts
+++ b/libs/repo-module/test/module/find-by-faculty.test.ts
@@ -6,7 +6,7 @@ beforeAll(() => setup(db, { restore: false }))
 afterAll(() => teardown(db))
 
 async function findByFaculty(faculty: string) {
-  return Repo.Module!.findByFaculty(faculty)
+  return Repo.Module.findByFaculty(faculty)
 }
 
 it('returns an array of modules', async () => {
@@ -17,7 +17,7 @@ it('returns an array of modules', async () => {
 })
 
 it('returns [] on invalid faculty', async () => {
-  await Repo.Module!.findByFaculty('NOT_VALID').then((res) => {
+  await Repo.Module.findByFaculty('NOT_VALID').then((res) => {
     expect(res).toStrictEqual([])
   })
 })

--- a/libs/repo-module/test/module/get-eligible-modules.test.ts
+++ b/libs/repo-module/test/module/get-eligible-modules.test.ts
@@ -5,7 +5,7 @@ beforeAll(() => setup(db, { restore: false }))
 afterAll(() => teardown(db))
 
 it('returns an array of strings', async () => {
-  await Repo.Module!.getEligibleModules(['CS1101S'], [], []).then((codes) => {
+  await Repo.Module.getEligibleModules(['CS1101S'], [], []).then((codes) => {
     expect(codes).toBeInstanceOf(Array)
     codes.forEach((e) => expect(typeof e).toBe('string'))
     t.moduleCodes = codes
@@ -17,7 +17,7 @@ it('returns correct modules', async () => {
 })
 
 it('returns correct modules', async () => {
-  await Repo.Module!.getEligibleModules([], [], ['CS1101S']).then((codes) => {
+  await Repo.Module.getEligibleModules([], [], ['CS1101S']).then((codes) => {
     expect(codes).toIncludeSameMembers(['CS2109S'])
   })
 })

--- a/libs/repo-module/test/module/get-postreqs.test.ts
+++ b/libs/repo-module/test/module/get-postreqs.test.ts
@@ -8,14 +8,14 @@ afterAll(() => teardown(db))
 
 describe('single query', () => {
   it('returns an array', async () => {
-    await Repo.Module!.getPostReqs(['MA2001']).then((res) => {
+    await Repo.Module.getPostReqs(['MA2001']).then((res) => {
       expect(res).toBeInstanceOf(Array)
       t.postReqsCodes = res
     })
   })
 
   it('returns correct modules', async () => {
-    await Repo.Module!.findOneByOrFail({
+    await Repo.Module.findOneByOrFail({
       moduleCode: 'MA2001',
     }).then((module) => {
       expect(t.postReqsCodes).toIncludeSameMembers(module.fulfillRequirements)
@@ -25,7 +25,7 @@ describe('single query', () => {
 
 describe('multi query', () => {
   it('returns an array', async () => {
-    await Repo.Module!.getPostReqs(['MA2001', 'CS1010']).then((res) => {
+    await Repo.Module.getPostReqs(['MA2001', 'CS1010']).then((res) => {
       expect(res).toBeInstanceOf(Array)
       t.postReqsCodes = res
     })
@@ -33,7 +33,7 @@ describe('multi query', () => {
 
   it('returns correct modules', async () => {
     const codes: string[] = []
-    await Repo.Module!.findBy({
+    await Repo.Module.findBy({
       moduleCode: In(['MA2001', 'CS1010']),
     }).then((modules) => {
       modules.forEach((module) => {
@@ -45,7 +45,7 @@ describe('multi query', () => {
 })
 
 it('returns [] for modules with no post reqs', async () => {
-  await Repo.Module!.getPostReqs(['CP2106']).then((res) => {
+  await Repo.Module.getPostReqs(['CP2106']).then((res) => {
     expect(res).toStrictEqual([])
   })
 })

--- a/libs/repo-module/test/module/get-suggested-modules/from-many.test.ts
+++ b/libs/repo-module/test/module/get-suggested-modules/from-many.test.ts
@@ -5,7 +5,7 @@ beforeAll(() => setup(db, { restore: false }))
 afterAll(() => teardown(db))
 
 it('returns an array of strings', async () => {
-  await Repo.Module!.getSuggestedModules(
+  await Repo.Module.getSuggestedModules(
     ['CS1010', 'CG2111A', 'CS1231'], // done
     ['IT2002'], // doing
     ['CS1010', 'CS1231'], // selected

--- a/libs/repo-module/test/module/get-suggested-modules/from-one.test.ts
+++ b/libs/repo-module/test/module/get-suggested-modules/from-one.test.ts
@@ -10,7 +10,7 @@ export async function suggest(
   selected: string[],
   required: string[]
 ) {
-  return Repo.Module!.getSuggestedModules(done, doing, selected, required)
+  return Repo.Module.getSuggestedModules(done, doing, selected, required)
 }
 
 it('returns an array of modules', async () => {

--- a/libs/repo-module/test/module/get-unlocked-modules.test.ts
+++ b/libs/repo-module/test/module/get-unlocked-modules.test.ts
@@ -9,7 +9,7 @@ async function getUnlockedModules(
   doing: string[],
   query: string
 ) {
-  return Repo.Module!.getUnlockedModules(done, doing, query)
+  return Repo.Module.getUnlockedModules(done, doing, query)
 }
 
 it('returns an array of strings', async () => {

--- a/libs/repo-module/test/module/initialize.test.ts
+++ b/libs/repo-module/test/module/initialize.test.ts
@@ -20,21 +20,21 @@ beforeAll(() => setup(db))
 afterAll(() => teardown(db, true))
 
 it('initial count', async () => {
-  await Repo.Module!.count().then((c) => {
+  await Repo.Module.count().then((c) => {
     expect(c).toBeGreaterThan(6000)
     count = c
   })
 })
 
 it('returns a module', async () => {
-  await Repo.Module!.initialize(m).then((res) => {
+  await Repo.Module.initialize(m).then((res) => {
     expect(res).toBeInstanceOf(Module)
     t.modules = [res]
   })
 })
 
 it('increments the count by 1', async () => {
-  await Repo.Module!.count().then((c) => {
+  await Repo.Module.count().then((c) => {
     expect(c).toEqual(count + 1)
   })
 })

--- a/libs/repo-pull/test/module-condensed.test.ts
+++ b/libs/repo-pull/test/module-condensed.test.ts
@@ -19,7 +19,7 @@ beforeAll(() =>
 afterAll(() => teardown(db))
 
 test('gather data', async () => {
-  await Repo.ModuleCondensed!.deleteAll()
+  await Repo.ModuleCondensed.deleteAll()
   pullOnEmpty = await moduleCondensedRepo.pull()
   pullOnFull = await moduleCondensedRepo.pull()
   written = await moduleCondensedRepo.find()

--- a/libs/repo-user/test/can-take-module.test.ts
+++ b/libs/repo-user/test/can-take-module.test.ts
@@ -8,7 +8,7 @@ const db = getSource(dbName)
 beforeAll(() =>
   setup(db)
     .then(() =>
-      Repo.User!.initialize({
+      Repo.User.initialize({
         ...init.user1,
         modulesDone: ['MA2001'],
         modulesDoing: ['MA2219'],
@@ -23,7 +23,7 @@ afterAll(() => teardown(db))
 it('resolves modules not taken', async () => {
   const modulesTested = ['MA2101', 'MA1100', 'CS2040S', 'CS1010S']
   await Promise.all(
-    modulesTested.map((x) => Repo.User!.canTakeModule(t.user!, x))
+    modulesTested.map((x) => Repo.User.canTakeModule(t.user!, x))
   ).then((res) => {
     expect(res).toStrictEqual([true, false, false, true])
   })
@@ -33,14 +33,14 @@ it('errors on modules taking/taken before', async () => {
   // one done, one doing
   const modulesTested = ['MA2001', 'MA2219']
   await Promise.all(
-    modulesTested.map((x) => Repo.User!.canTakeModule(t.user!, x))
+    modulesTested.map((x) => Repo.User.canTakeModule(t.user!, x))
   ).then((res) => {
     expect(res).toStrictEqual([false, false])
   })
 })
 
 it('errors on invalid code', async () => {
-  await Repo.User!.canTakeModule(t.user!, 'NOT_VALID').then((res) => {
+  await Repo.User.canTakeModule(t.user!, 'NOT_VALID').then((res) => {
     expect(res).toStrictEqual(false)
   })
 })

--- a/libs/repo-user/test/degree-methods.test.ts
+++ b/libs/repo-user/test/degree-methods.test.ts
@@ -10,8 +10,8 @@ beforeAll(() =>
   setup(db)
     .then(() =>
       Promise.all([
-        Repo.User!.initialize(init.user1),
-        Repo.Degree!.initialize(init.degree1),
+        Repo.User.initialize(init.user1),
+        Repo.Degree.initialize(init.degree1),
       ])
     )
     .then(([user, degree]) => {
@@ -26,7 +26,7 @@ describe('User.insertDegrees', () => {
 
   it('returns a user', async () => {
     // get user with all relations
-    await Repo.User!.insertDegrees(t.user!, [t.degree!.id]).then((user) => {
+    await Repo.User.insertDegrees(t.user!, [t.degree!.id]).then((user) => {
       expect(user).toBeInstanceOf(User)
       t.user = user
     })
@@ -42,20 +42,20 @@ describe('User.findDegree', () => {
   beforeEach(expect.hasAssertions)
 
   it('returns a degree', async () => {
-    await Repo.User!.findDegree(t.user!, t.degree!.id).then((degree) => {
+    await Repo.User.findDegree(t.user!, t.degree!.id).then((degree) => {
       expect(degree).toBeInstanceOf(Degree)
     })
   })
 
   it('finds correct degree id', async () => {
-    await Repo.User!.findDegree(t.user!, t.degree!.id).then((degree) => {
+    await Repo.User.findDegree(t.user!, t.degree!.id).then((degree) => {
       expect(degree.id).toBe(t.degree!.id)
     })
   })
 
   it('errors if degree not found', async () => {
     await expect(() =>
-      Repo.User!.findDegree(t.user!, 'NOT_VALID')
+      Repo.User.findDegree(t.user!, 'NOT_VALID')
     ).rejects.toThrowError(Error('Degree not found in User'))
   })
 })
@@ -64,7 +64,7 @@ describe('User.removeDegree', () => {
   beforeEach(expect.hasAssertions)
 
   it('returns a user', async () => {
-    await Repo.User!.removeDegree(t.user!, t.degree!.id).then((user) => {
+    await Repo.User.removeDegree(t.user!, t.degree!.id).then((user) => {
       expect(user).toBeInstanceOf(User)
       t.user = user
     })
@@ -76,7 +76,7 @@ describe('User.removeDegree', () => {
 
   it('errors if degree not found', async () => {
     await expect(() =>
-      Repo.User!.removeDegree(t.user!, 'NOT_VALID')
+      Repo.User.removeDegree(t.user!, 'NOT_VALID')
     ).rejects.toThrowError(Error('Degree not found in User'))
   })
 })

--- a/libs/repo-user/test/delete.test.ts
+++ b/libs/repo-user/test/delete.test.ts
@@ -10,17 +10,17 @@ beforeAll(() =>
   setup(db)
     .then(() => {
       return Promise.all([
-        Repo.User!.initialize(init.user1),
-        Repo.Degree!.initialize(init.degree1),
+        Repo.User.initialize(init.user1),
+        Repo.Degree.initialize(init.degree1),
       ])
     })
     .then(([user, degree]) => {
       t.user = user
       t.degree = degree
-      return Repo.User!.insertDegrees(t.user, [t.degree.id])
+      return Repo.User.insertDegrees(t.user, [t.degree.id])
     })
     .then(() =>
-      Repo.Graph!.initialize({
+      Repo.Graph.initialize({
         userId: t.user!.id,
         degreeId: t.degree!.id,
         modulesPlacedCodes: [],
@@ -35,29 +35,27 @@ beforeAll(() =>
 afterAll(() => teardown(db))
 
 it('user has 1 degree', async () => {
-  await Repo.User!.findOneById(t.user!.id).then((user) => {
+  await Repo.User.findOneById(t.user!.id).then((user) => {
     expect(user.savedDegrees).toHaveLength(1)
   })
 })
 
 it('successfully deletes user', async () => {
-  await Repo.User!.remove(t.user!).then((user) => {
+  await Repo.User.remove(t.user!).then((user) => {
     expect(user.id).toEqual(undefined)
   })
 })
 
 it('user does not exist', async () => {
-  await expect(() => Repo.User!.findOneById(t.user!.id)).rejects.toThrow(Error)
+  await expect(() => Repo.User.findOneById(t.user!.id)).rejects.toThrow(Error)
 })
 
 it('degree exists', async () => {
-  await Repo.Degree!.findOneById(t.degree!.id).then((degree) => {
+  await Repo.Degree.findOneById(t.degree!.id).then((degree) => {
     expect(degree).toBeInstanceOf(Degree)
   })
 })
 
 it('graph does not exist', async () => {
-  await expect(() => Repo.Graph!.findOneById(t.graph!.id)).rejects.toThrow(
-    Error
-  )
+  await expect(() => Repo.Graph.findOneById(t.graph!.id)).rejects.toThrow(Error)
 })

--- a/libs/repo-user/test/get-eligible-modules.test.ts
+++ b/libs/repo-user/test/get-eligible-modules.test.ts
@@ -8,7 +8,7 @@ const db = getSource(dbName)
 beforeAll(() =>
   setup(db)
     .then(() =>
-      Repo.User!.initialize({
+      Repo.User.initialize({
         ...init.user1,
         modulesDone: ['CS1101S'],
       })
@@ -20,7 +20,7 @@ beforeAll(() =>
 afterAll(() => teardown(db))
 
 it('adds correct modules', async () => {
-  await Repo.User!.getEligibleModules(t.user!).then((modules) => {
+  await Repo.User.getEligibleModules(t.user!).then((modules) => {
     const codes = modules.map(flatten.module)
     expect(codes).toIncludeSameMembers(['CS2109S'])
   })

--- a/libs/repo-user/test/get-postreqs.test.ts
+++ b/libs/repo-user/test/get-postreqs.test.ts
@@ -9,7 +9,7 @@ const db = getSource(dbName)
 beforeAll(() =>
   setup(db)
     .then(() =>
-      Repo.User!.initialize({
+      Repo.User.initialize({
         ...init.user1,
         modulesDone: ['MA2001'],
         modulesDoing: ['MA2101'],
@@ -22,13 +22,13 @@ beforeAll(() =>
 afterAll(() => teardown(db))
 
 it('returns an array of modules', async () => {
-  await Repo.User!.getPostReqs(t.user!).then((res) => {
+  await Repo.User.getPostReqs(t.user!).then((res) => {
     res.forEach((module) => expect(module).toBeInstanceOf(Module))
   })
 })
 
 it("doesn't contain modules doing", async () => {
-  await Repo.User!.getPostReqs(t.user!).then((res) => {
+  await Repo.User.getPostReqs(t.user!).then((res) => {
     const codes = res.map(flatten.module)
     expect(codes).not.toContain('MA2101')
   })
@@ -36,8 +36,8 @@ it("doesn't contain modules doing", async () => {
 
 it('gets correct post-reqs', async () => {
   await Promise.all([
-    Repo.User!.getPostReqs(t.user!),
-    Repo.Module!.findOneByOrFail({ moduleCode: 'MA2001' }),
+    Repo.User.getPostReqs(t.user!),
+    Repo.Module.findOneByOrFail({ moduleCode: 'MA2001' }),
   ]).then(([userPostReqs, module]) => {
     const postReqCodes = userPostReqs.map(flatten.module)
     const expectedCodes = module.fulfillRequirements
@@ -49,7 +49,7 @@ describe('handles empty fulfillRequirements', () => {
   beforeEach(expect.hasAssertions)
 
   it('CP2106.fulfillRequirements is empty', async () => {
-    await Repo.Module!.findOneByOrFail({ moduleCode: 'CP2106' }).then(
+    await Repo.Module.findOneByOrFail({ moduleCode: 'CP2106' }).then(
       (module) => {
         expect(module.fulfillRequirements).toBe('')
       }
@@ -59,8 +59,8 @@ describe('handles empty fulfillRequirements', () => {
   it('returns []', async () => {
     // init new user with CP2106
     // CP2106 has empty string fulfillRequirements
-    await Repo.User!.initialize({ ...init.user2, modulesDone: ['CP2106'] })
-      .then((res) => Repo.User!.getPostReqs(res))
+    await Repo.User.initialize({ ...init.user2, modulesDone: ['CP2106'] })
+      .then((res) => Repo.User.getPostReqs(res))
       .then((postReqs) => {
         expect(postReqs).toStrictEqual([])
       })

--- a/libs/repo-user/test/get-unlocked-modules.test.ts
+++ b/libs/repo-user/test/get-unlocked-modules.test.ts
@@ -8,7 +8,7 @@ const db = getSource(dbName)
 beforeAll(() =>
   setup(db)
     .then(() =>
-      Repo.User!.initialize({
+      Repo.User.initialize({
         ...init.user1,
         modulesDone: ['CS1010'],
       })
@@ -20,7 +20,7 @@ beforeAll(() =>
 afterAll(() => teardown(db))
 
 async function getUnlockedModules(user: User, moduleCode: string) {
-  return Repo.User!.getUnlockedModules(user, moduleCode)
+  return Repo.User.getUnlockedModules(user, moduleCode)
 }
 
 it('returns an array of modules', async () => {
@@ -39,7 +39,7 @@ it('gets correct modules', async () => {
 
 it('does not modify User', async () => {
   // Also loads relations
-  await Repo.User!.findOneById(t.user!.id).then((res) => {
+  await Repo.User.findOneById(t.user!.id).then((res) => {
     const modulesDoneCodes = res.modulesDone.map(flatten.module)
     expect(modulesDoneCodes).toEqual(['CS1010'])
   })

--- a/libs/repo-user/test/has-taken-module.test.ts
+++ b/libs/repo-user/test/has-taken-module.test.ts
@@ -8,7 +8,7 @@ const db = getSource(dbName)
 
 beforeAll(() =>
   setup(db)
-    .then(() => Repo.User!.initialize(init.user1))
+    .then(() => Repo.User.initialize(init.user1))
     .then((user) => {
       t.user = user
     })
@@ -16,7 +16,7 @@ beforeAll(() =>
 afterAll(() => teardown(db))
 
 async function hasTakenModule(user: User, moduleCode: string) {
-  return Repo.User!.hasTakenModule(user, moduleCode)
+  return Repo.User.hasTakenModule(user, moduleCode)
 }
 
 it('returns true for modulesDone', async () => {

--- a/libs/repo-user/test/initialize.test.ts
+++ b/libs/repo-user/test/initialize.test.ts
@@ -10,33 +10,33 @@ beforeAll(() => setup(db))
 afterAll(() => teardown(db))
 
 it('initial count', async () => {
-  await Repo.User!.count().then((count) => {
+  await Repo.User.count().then((count) => {
     expect(count).toEqual(0)
   })
 })
 
 it('returns a user', async () => {
-  await Repo.User!.initialize(init.user1).then((user) => {
+  await Repo.User.initialize(init.user1).then((user) => {
     expect(user).toBeInstanceOf(User)
     t.user = user
   })
 })
 
 it('increments the count by 1', async () => {
-  await Repo.User!.count().then((count) => {
+  await Repo.User.count().then((count) => {
     expect(count).toEqual(1)
   })
 })
 
 it('creates new user even with same auth0 id', async () => {
-  await Repo.User!.initialize(init.user1).then((user) => {
+  await Repo.User.initialize(init.user1).then((user) => {
     expect(user.id).not.toEqual(t.user!.id)
     expect(user.authZeroId).toEqual(t.user!.authZeroId)
   })
 })
 
 it('increments the count by 1 again', async () => {
-  await Repo.User!.count().then((count) => {
+  await Repo.User.count().then((count) => {
     // same as previous count
     expect(count).toEqual(2)
   })

--- a/libs/repo-user/test/set-module-status.test.ts
+++ b/libs/repo-user/test/set-module-status.test.ts
@@ -10,7 +10,7 @@ const db = getSource(dbName)
 beforeAll(() =>
   setup(db)
     .then(() =>
-      Repo.User!.initialize({
+      Repo.User.initialize({
         ...init.user1,
         modulesDone: ['MA2001'],
         modulesDoing: ['MA2219'],
@@ -41,7 +41,7 @@ async function setModuleStatus(
   moduleCode: string,
   status: ModuleStatus
 ) {
-  return Repo.User!.setModuleStatus(user, moduleCode, status)
+  return Repo.User.setModuleStatus(user, moduleCode, status)
 }
 
 it('done -> doing', async () => {

--- a/libs/test-env/src/environment.ts
+++ b/libs/test-env/src/environment.ts
@@ -26,7 +26,7 @@ type SetupOptions = {
 /**
  * initialize with default db
  */
-const Repo: Repositories = {}
+let Repo: Repositories
 
 /**
  * pre-test setup
@@ -46,11 +46,13 @@ export async function setup(
       /**
        * overwrite default db with the setup function's db parameter
        */
-      Repo.User = new UserRepository(db)
-      Repo.Degree = new DegreeRepository(db)
-      Repo.Graph = new GraphRepository(db)
-      Repo.Module = new ModuleRepository(db)
-      Repo.ModuleCondensed = new ModuleCondensedRepository(db)
+      Repo = {
+        User: new UserRepository(db),
+        Degree: new DegreeRepository(db),
+        Graph: new GraphRepository(db),
+        Module: new ModuleRepository(db),
+        ModuleCondensed: new ModuleCondensedRepository(db),
+      }
     })
   if (db.options.database === undefined) return
   if (opts.restore) {

--- a/libs/types/src/repository.ts
+++ b/libs/types/src/repository.ts
@@ -114,9 +114,9 @@ export interface IModuleCondensedRepository extends EModuleCondensed {
 }
 
 export type Repositories = {
-  Module?: IModuleRepository
-  ModuleCondensed?: IModuleCondensedRepository
-  User?: IUserRepository
-  Degree?: IDegreeRepository
-  Graph?: IGraphRepository
+  Module: IModuleRepository
+  ModuleCondensed: IModuleCondensedRepository
+  User: IUserRepository
+  Degree: IDegreeRepository
+  Graph: IGraphRepository
 }


### PR DESCRIPTION
### Summary of changes

- use then chaining for module repo methods
- remove all `!` of `Repo.*` of test-env
  - test this with `rg "(Module\!|User\!|ModuleCondensed\!|Degree\!|Graph\!)"` from root
