### PR TITLE
feat(api): set module status

### DIFF
--- a/apps/server/src/api/user.ts
+++ b/apps/server/src/api/user.ts
@@ -123,4 +123,15 @@ export class UserApi {
     const { email } = req.body
     return api.userLogin(authZeroId, email).then(flatten.user)
   }
+
+  static setModuleStatus = (api: Api) => async (req: Request) => {
+    const id = req.params.userId
+    const { moduleCodes, status } = req.body
+    return api.userRepo
+      .findOneOrFail({
+        where: { id },
+        relations: api.relations.user,
+      })
+      .then((user) => api.userRepo.setModuleStatus(user, moduleCodes, status))
+  }
 }

--- a/apps/server/src/api/user.ts
+++ b/apps/server/src/api/user.ts
@@ -34,6 +34,8 @@ export class UserApi {
    * gets one User by primary keys
    * at least one of id, authZeroId, or email
    *
+   * UNUSED
+   *
    * @param {Api} api
    */
   static getByPrimaryKeys =

--- a/apps/server/src/routes.ts
+++ b/apps/server/src/routes.ts
@@ -8,6 +8,9 @@ import {
 } from './api'
 import { body, param, query } from 'express-validator'
 import { validModuleCode } from '@modtree/utils'
+import { ModuleStatus } from '@modtree/types'
+
+const moduleStatuses = Object.values(ModuleStatus)
 
 export const routes: Route[] = [
   /**
@@ -64,6 +67,12 @@ export const routes: Route[] = [
     route: '/user/:userId',
     fn: UserApi.delete,
     validators: [],
+  },
+  {
+    method: 'patch',
+    route: '/user/:userId/module',
+    fn: UserApi.setModuleStatus,
+    validators: [body('status').isString().isIn(moduleStatuses)],
   },
 
   /**

--- a/apps/server/test/user/:userId/module/[PATCH].test.ts
+++ b/apps/server/test/user/:userId/module/[PATCH].test.ts
@@ -1,0 +1,64 @@
+import request from 'supertest'
+import { getApp } from 'app'
+import type { Express } from 'express'
+import { getSource } from '@modtree/typeorm-config'
+import { oneUp } from '@modtree/utils'
+import { setup, teardown } from '@modtree/test-env'
+import { Api } from '@modtree/repo-api'
+import { ModuleStatus } from '@modtree/types'
+
+const dbName = oneUp(__filename)
+const db = getSource(dbName)
+let app: Express
+let api: Api
+let findOneOrFail: jest.SpyInstance
+let setModuleStatus: jest.SpyInstance
+
+beforeAll(() =>
+  setup(db).then(() => {
+    api = new Api(db)
+    app = getApp(api)
+    findOneOrFail = jest.spyOn(api.userRepo, 'findOneOrFail')
+    setModuleStatus = jest.spyOn(api.userRepo, 'setModuleStatus')
+  })
+)
+beforeEach(() => jest.clearAllMocks())
+afterAll(() => teardown(db))
+
+async function testRequest() {
+  await request(app)
+    .patch('/user/924a4c06-4ccb-4208-8791-ecae4099a763/module')
+    .send({
+      status: ModuleStatus.DONE,
+      moduleCodes: ['MA2001', 'CS1231S'],
+    })
+}
+
+test('`findOneOrFail` is called once', async () => {
+  await testRequest()
+
+  expect(findOneOrFail).toBeCalledTimes(1)
+})
+
+test('`setModuleStatus` is called zero times', async () => {
+  /**
+   * called zero times because there is no valid user found to operate on
+   */
+  await testRequest()
+
+  expect(setModuleStatus).toBeCalledTimes(0)
+})
+
+test('`findOneOrFail` is called with correct args', async () => {
+  await testRequest()
+
+  expect(findOneOrFail).toBeCalledWith({
+    where: { id: '924a4c06-4ccb-4208-8791-ecae4099a763' },
+    relations: {
+      modulesDone: true,
+      modulesDoing: true,
+      savedDegrees: true,
+      savedGraphs: true,
+    },
+  })
+})

--- a/libs/repo-user/test/set-module-status.test.ts
+++ b/libs/repo-user/test/set-module-status.test.ts
@@ -36,12 +36,16 @@ function expectUserModules(
   expect(modulesDoing).toIncludeSameMembers(modulesDoingCodes)
 }
 
+/**
+ * Tests setModuleStatus with 1 module.
+ * The original repo function works with many modules.
+ */
 async function setModuleStatus(
   user: User,
   moduleCode: string,
   status: ModuleStatus
 ) {
-  return Repo.User.setModuleStatus(user, moduleCode, status)
+  return Repo.User.setModuleStatus(user, [moduleCode], status)
 }
 
 it('done -> doing', async () => {

--- a/libs/types/src/repository.ts
+++ b/libs/types/src/repository.ts
@@ -69,7 +69,7 @@ export interface IUserRepository extends EUser {
   removeDegree(user: IUser, degreeId: string): Promise<IUser>
   setModuleStatus(
     user: IUser,
-    moduleCode: string,
+    moduleCodes: string[],
     status: ModuleStatus
   ): Promise<IUser>
 }


### PR DESCRIPTION
### Summary of changes

- `User.setModuleStatus` now takes in an array of module codes, instead of a single module code
- Route at `user/:userId/module`

### Testing

- Update repo test to send an array instead of a single module code
- Add test for server endpoint
