### PR TITLE
feat(frontend): cache management for module condensed

### DIFF
--- a/apps/server/src/api/module-condensed.ts
+++ b/apps/server/src/api/module-condensed.ts
@@ -14,10 +14,10 @@ export class ModuleCondensedApi {
    * @param {Api} api
    */
   static list = (api: Api) => (req: CustomReqQuery<ModuleCodes>) => {
-    if (req.query.moduleCodes) {
+    if (Array.isArray(req.query.moduleCodes)) {
       return api.moduleCondensedRepo.findByCodes(req.query.moduleCodes)
     } else {
-      return api.moduleCondensedRepo.find()
+      return []
     }
   }
 

--- a/apps/server/test/modules-condensed/[GET].test.ts
+++ b/apps/server/test/modules-condensed/[GET].test.ts
@@ -27,15 +27,9 @@ afterAll(() => teardown(db))
 const testRequest = () => request(app).get('/modules-condensed')
 
 describe('without params', () => {
-  test('`find` is called once', async () => {
+  test('`find` is not called', async () => {
     await testRequest()
-    expect(find).toBeCalledTimes(1)
-  })
-
-  test('`find` is called with correct args', async () => {
-    await testRequest()
-
-    expect(find).toBeCalledWith()
+    expect(find).toBeCalledTimes(0)
   })
 })
 

--- a/apps/web/components/user-profile/modules/add-doing.tsx
+++ b/apps/web/components/user-profile/modules/add-doing.tsx
@@ -6,15 +6,20 @@ import { SettingsSearchBox } from '@/ui/search'
 import { useAppDispatch, useAppSelector } from '@/store/redux'
 import { updateModulesDoing } from '@/store/user'
 import { SelectedModules } from './selected-modules'
-import { updateCachedModulesCondensed } from '@/utils/backend'
+import { backend } from '@/utils/backend'
+import { useUser } from '@/utils/auth0'
 
 export function AddDoing(props: { setPage: SetState<Pages['Modules']> }) {
   const dispatch = useAppDispatch()
+  const { user } = useUser()
   const buildList = useAppSelector((state) => state.search.buildList)
   function confirm() {
     const codes = buildList.map((m) => m.moduleCode)
+    backend.patch(`/user/${user.modtree.id}/module`, {
+      status: 'doing',
+      moduleCodes: codes,
+    })
     dispatch(updateModulesDoing(codes))
-    updateCachedModulesCondensed(dispatch, codes)
     props.setPage('main')
   }
   return (

--- a/apps/web/components/user-profile/modules/add-doing.tsx
+++ b/apps/web/components/user-profile/modules/add-doing.tsx
@@ -32,11 +32,7 @@ export function AddDoing(props: { setPage: SetState<Pages['Modules']> }) {
       >
         <h6>Modules</h6>
         <div className="flex flex-row space-x-2 mb-4">
-          <div className="w-64 flex">
-            <div className="w-64 fixed">
-              <SettingsSearchBox />
-            </div>
-          </div>
+          <SettingsSearchBox />
           <Button>Add Module</Button>
         </div>
         <SelectedModules modules={buildList} />

--- a/apps/web/components/user-profile/modules/add-done.tsx
+++ b/apps/web/components/user-profile/modules/add-done.tsx
@@ -6,7 +6,6 @@ import { SettingsSearchBox } from '@/ui/search'
 import { useAppDispatch, useAppSelector } from '@/store/redux'
 import { updateModulesDone } from '@/store/user'
 import { SelectedModules } from './selected-modules'
-import { updateCachedModulesCondensed } from '@/utils/backend'
 
 export function AddDone(props: { setPage: SetState<Pages['Modules']> }) {
   const dispatch = useAppDispatch()
@@ -14,7 +13,6 @@ export function AddDone(props: { setPage: SetState<Pages['Modules']> }) {
   function confirm() {
     const codes = buildList.map((m) => m.moduleCode)
     dispatch(updateModulesDone(codes))
-    updateCachedModulesCondensed(dispatch, codes)
     props.setPage('main')
   }
   return (

--- a/apps/web/components/user-profile/modules/add-done.tsx
+++ b/apps/web/components/user-profile/modules/add-done.tsx
@@ -25,11 +25,7 @@ export function AddDone(props: { setPage: SetState<Pages['Modules']> }) {
       >
         <h6>Modules</h6>
         <div className="flex flex-row space-x-2 mb-4">
-          <div className="w-64 flex">
-            <div className="w-64 fixed">
-              <SettingsSearchBox />
-            </div>
-          </div>
+          <SettingsSearchBox />
           <Button>Add Module</Button>
         </div>
         <SelectedModules modules={buildList} />

--- a/apps/web/components/user-profile/modules/main.tsx
+++ b/apps/web/components/user-profile/modules/main.tsx
@@ -11,14 +11,17 @@ import { useEffect } from 'react'
 import { moduleCondensedCache } from '@/utils/modules-condensed-cache'
 
 export function Main(props: { setPage: SetState<Pages['Modules']> }) {
+  const dispatch = useAppDispatch()
   const user = useAppSelector((state) => state.user)
   const cache = useAppSelector((state) => state.cache.modulesCondensed)
 
+  /**
+   * update the cache with required modules
+   */
   useEffect(() => {
     moduleCondensedCache.load([...user.modulesDone, ...user.modulesDoing])
   }, [user.modulesDone, user.modulesDoing])
 
-  const dispatch = useAppDispatch()
   const hasModules = {
     done: user.modulesDone.length !== 0,
     doing: user.modulesDoing.length !== 0,
@@ -31,13 +34,7 @@ export function Main(props: { setPage: SetState<Pages['Modules']> }) {
           addButtonColor={hasModules.doing ? 'gray' : 'green'}
           addButtonText={hasModules.doing ? 'Modify' : 'Add doing'}
           onAddClick={() => {
-            backend
-              .get('/modules-condensed', {
-                params: { moduleCodes: user.modulesDoing },
-              })
-              .then((res) => {
-                dispatch(setBuildList(res.data))
-              })
+            dispatch(setBuildList(user.modulesDoing.map((code) => cache[code])))
             props.setPage('add-doing')
           }}
         >
@@ -65,13 +62,7 @@ export function Main(props: { setPage: SetState<Pages['Modules']> }) {
           addButtonColor={hasModules.done ? 'gray' : 'green'}
           addButtonText={hasModules.done ? 'Modify' : 'Add done'}
           onAddClick={() => {
-            backend
-              .get('/modules-condensed', {
-                params: { moduleCodes: user.modulesDone },
-              })
-              .then((res) => {
-                dispatch(setBuildList(res.data))
-              })
+            dispatch(setBuildList(user.modulesDone.map((code) => cache[code])))
             props.setPage('add-done')
           }}
         >

--- a/apps/web/components/user-profile/modules/main.tsx
+++ b/apps/web/components/user-profile/modules/main.tsx
@@ -5,9 +5,8 @@ import { text } from 'text'
 import { dashed } from '@/utils/array'
 import { Row } from '@/ui/settings/lists/rows'
 import { useAppDispatch, useAppSelector } from '@/store/redux'
-import { useEffect } from 'react'
-import { updateCachedModulesCondensed } from '@/utils/backend'
 import { setBuildList } from '@/store/search'
+import { backend } from '@/utils/backend'
 
 export function Main(props: { setPage: SetState<Pages['Modules']> }) {
   const user = useAppSelector((state) => state.user)
@@ -19,10 +18,6 @@ export function Main(props: { setPage: SetState<Pages['Modules']> }) {
     done: user.modulesDone.length !== 0,
     doing: user.modulesDoing.length !== 0,
   }
-  useEffect(() => {
-    const codes = [...user.modulesDone, ...user.modulesDoing]
-    updateCachedModulesCondensed(dispatch, codes)
-  }, [user.modulesDone, user.modulesDoing])
   return (
     <>
       <div className="mb-12">
@@ -31,11 +26,13 @@ export function Main(props: { setPage: SetState<Pages['Modules']> }) {
           addButtonColor={hasModules.doing ? 'gray' : 'green'}
           addButtonText={hasModules.doing ? 'Modify' : 'Add doing'}
           onAddClick={() => {
-            dispatch(
-              setBuildList(
-                user.modulesDoing.map((code) => cachedModulesCondensed[code])
-              )
-            )
+            backend
+              .get('/modules-condensed', {
+                params: { moduleCodes: user.modulesDoing },
+              })
+              .then((res) => {
+                dispatch(setBuildList(res.data))
+              })
             props.setPage('add-doing')
           }}
         >
@@ -63,11 +60,13 @@ export function Main(props: { setPage: SetState<Pages['Modules']> }) {
           addButtonColor={hasModules.done ? 'gray' : 'green'}
           addButtonText={hasModules.done ? 'Modify' : 'Add done'}
           onAddClick={() => {
-            dispatch(
-              setBuildList(
-                user.modulesDone.map((code) => cachedModulesCondensed[code])
-              )
-            )
+            backend
+              .get('/modules-condensed', {
+                params: { moduleCodes: [], all: false },
+              })
+              .then((res) => {
+                dispatch(setBuildList(res.data))
+              })
             props.setPage('add-done')
           }}
         >

--- a/apps/web/components/user-profile/modules/main.tsx
+++ b/apps/web/components/user-profile/modules/main.tsx
@@ -7,13 +7,29 @@ import { Row } from '@/ui/settings/lists/rows'
 import { useAppDispatch, useAppSelector } from '@/store/redux'
 import { setBuildList } from '@/store/search'
 import { backend } from '@/utils/backend'
+import { ModuleCondensed } from '@modtree/entity'
+import { useEffect, useState } from 'react'
 
 export function Main(props: { setPage: SetState<Pages['Modules']> }) {
   const user = useAppSelector((state) => state.user)
+  const [cache, setCache] = useState<Record<string, ModuleCondensed>>({})
+
+  useEffect(() => {
+    backend
+      .get('/modules-condensed', {
+        params: { moduleCodes: [...user.modulesDone, ...user.modulesDoing] },
+      })
+      .then((res) => {
+        const newCache: Record<string, ModuleCondensed> = {}
+        const modules: ModuleCondensed[] = res.data
+        modules.forEach((module) => {
+          newCache[module.moduleCode] = module
+        })
+        setCache(newCache)
+      })
+  }, [user.modulesDone, user.modulesDoing])
+
   const dispatch = useAppDispatch()
-  const cachedModulesCondensed = useAppSelector(
-    (state) => state.cache.modulesCondensed
-  )
   const hasModules = {
     done: user.modulesDone.length !== 0,
     doing: user.modulesDoing.length !== 0,
@@ -44,7 +60,7 @@ export function Main(props: { setPage: SetState<Pages['Modules']> }) {
                   <Row.Module key={dashed(code, index)}>
                     <span className="font-semibold">{code}</span>
                     <span className="mx-1">/</span>
-                    {cachedModulesCondensed[code]?.title}
+                    {cache[code]?.title}
                   </Row.Module>
                 ))}
               </div>
@@ -62,7 +78,7 @@ export function Main(props: { setPage: SetState<Pages['Modules']> }) {
           onAddClick={() => {
             backend
               .get('/modules-condensed', {
-                params: { moduleCodes: [], all: false },
+                params: { moduleCodes: user.modulesDone },
               })
               .then((res) => {
                 dispatch(setBuildList(res.data))
@@ -78,7 +94,7 @@ export function Main(props: { setPage: SetState<Pages['Modules']> }) {
                   <Row.Module key={dashed(code, index)}>
                     <span className="font-semibold">{code}</span>
                     <span className="mx-1">/</span>
-                    {cachedModulesCondensed[code].title}
+                    {cache[code].title}
                   </Row.Module>
                 ))}
               </div>

--- a/apps/web/components/user-profile/modules/main.tsx
+++ b/apps/web/components/user-profile/modules/main.tsx
@@ -6,7 +6,6 @@ import { dashed } from '@/utils/array'
 import { Row } from '@/ui/settings/lists/rows'
 import { useAppDispatch, useAppSelector } from '@/store/redux'
 import { setBuildList } from '@/store/search'
-import { backend } from '@/utils/backend'
 import { useEffect } from 'react'
 import { moduleCondensedCache } from '@/utils/modules-condensed-cache'
 

--- a/apps/web/components/user-profile/modules/main.tsx
+++ b/apps/web/components/user-profile/modules/main.tsx
@@ -7,20 +7,15 @@ import { Row } from '@/ui/settings/lists/rows'
 import { useAppDispatch, useAppSelector } from '@/store/redux'
 import { setBuildList } from '@/store/search'
 import { backend } from '@/utils/backend'
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { moduleCondensedCache } from '@/utils/modules-condensed-cache'
-import { ModuleCondensed } from '@modtree/entity'
 
 export function Main(props: { setPage: SetState<Pages['Modules']> }) {
   const user = useAppSelector((state) => state.user)
-  const [cache, setCache] = useState<Record<string, ModuleCondensed>>({})
+  const cache = useAppSelector((state) => state.cache.modulesCondensed)
 
   useEffect(() => {
-    moduleCondensedCache
-      .preload([...user.modulesDone, ...user.modulesDoing])
-      .then(() => {
-        setCache(moduleCondensedCache.getData())
-      })
+    moduleCondensedCache.load([...user.modulesDone, ...user.modulesDoing])
   }, [user.modulesDone, user.modulesDoing])
 
   const dispatch = useAppDispatch()

--- a/apps/web/components/user-profile/modules/main.tsx
+++ b/apps/web/components/user-profile/modules/main.tsx
@@ -7,25 +7,19 @@ import { Row } from '@/ui/settings/lists/rows'
 import { useAppDispatch, useAppSelector } from '@/store/redux'
 import { setBuildList } from '@/store/search'
 import { backend } from '@/utils/backend'
-import { ModuleCondensed } from '@modtree/entity'
 import { useEffect, useState } from 'react'
+import { moduleCondensedCache } from '@/utils/modules-condensed-cache'
+import { ModuleCondensed } from '@modtree/entity'
 
 export function Main(props: { setPage: SetState<Pages['Modules']> }) {
   const user = useAppSelector((state) => state.user)
   const [cache, setCache] = useState<Record<string, ModuleCondensed>>({})
 
   useEffect(() => {
-    backend
-      .get('/modules-condensed', {
-        params: { moduleCodes: [...user.modulesDone, ...user.modulesDoing] },
-      })
-      .then((res) => {
-        const newCache: Record<string, ModuleCondensed> = {}
-        const modules: ModuleCondensed[] = res.data
-        modules.forEach((module) => {
-          newCache[module.moduleCode] = module
-        })
-        setCache(newCache)
+    moduleCondensedCache
+      .preload([...user.modulesDone, ...user.modulesDoing])
+      .then(() => {
+        setCache(moduleCondensedCache.getData())
       })
   }, [user.modulesDone, user.modulesDoing])
 
@@ -94,7 +88,7 @@ export function Main(props: { setPage: SetState<Pages['Modules']> }) {
                   <Row.Module key={dashed(code, index)}>
                     <span className="font-semibold">{code}</span>
                     <span className="mx-1">/</span>
-                    {cache[code].title}
+                    {cache[code]?.title}
                   </Row.Module>
                 ))}
               </div>

--- a/apps/web/store/cache.ts
+++ b/apps/web/store/cache.ts
@@ -28,12 +28,10 @@ export const cache = createSlice({
       cache,
       action: PayloadAction<ModuleCondensed[]>
     ) => {
-      const { existingKeys, newState } = getState(cache.modulesCondensed)
-      action.payload
-        .filter((module) => !existingKeys.has(module.moduleCode))
-        .forEach((module) => {
-          newState[module.moduleCode] = module
-        })
+      const newState = cache.modulesCondensed
+      action.payload.forEach((module) => {
+        newState[module.moduleCode] = module
+      })
       cache.modulesCondensed = newState
     },
     addModulesToCache: (

--- a/apps/web/utils/backend.ts
+++ b/apps/web/utils/backend.ts
@@ -3,7 +3,6 @@ import { ActionCreatorWithOptionalPayload } from '@reduxjs/toolkit'
 import { AnyAction, Dispatch } from 'redux'
 import axios from 'axios'
 import { addModulesCondensedToCache } from '@/store/cache'
-import { ModtreeApiResponse } from '@modtree/types'
 import store from '@/store/redux'
 import { ModuleCondensed } from '@modtree/entity'
 

--- a/apps/web/utils/modules-condensed-cache.ts
+++ b/apps/web/utils/modules-condensed-cache.ts
@@ -8,8 +8,11 @@ class ModuleCondensedCache {
     this.data = {}
     this.codes = new Set<string>()
   }
+  getData(): Record<string, ModuleCondensed> {
+    return this.data
+  }
   async preload(codes: string[]): Promise<ModuleCondensed[]> {
-    const moduleCodes = codes.filter((code) => this.codes.has(code))
+    const moduleCodes = codes.filter((code) => !this.codes.has(code))
     return backend
       .get('/modules-condensed', {
         params: { moduleCodes },

--- a/apps/web/utils/modules-condensed-cache.ts
+++ b/apps/web/utils/modules-condensed-cache.ts
@@ -5,17 +5,15 @@ import { addModulesCondensedToCache } from '@/store/cache'
 
 class ModuleCondensedCache {
   private codes: Set<string>
-  private reduxState: Record<string, ModuleCondensed>
   private dispatch: AppDispatch
   constructor() {
     this.codes = new Set<string>()
-    this.reduxState = store.getState().cache.modulesCondensed
     this.dispatch = store.dispatch
   }
-  getData(): Record<string, ModuleCondensed> {
-    return this.reduxState
-  }
-  async preload(codes: string[]): Promise<ModuleCondensed[]> {
+  /**
+   * updates the cache
+   */
+  async load(codes: string[]) {
     const moduleCodes = codes.filter((code) => !this.codes.has(code))
     return backend
       .get('/modules-condensed', {
@@ -26,24 +24,8 @@ class ModuleCondensedCache {
         this.dispatch(addModulesCondensedToCache(modules))
         modules.forEach((module) => {
           this.codes.add(module.moduleCode)
-          // this.data[module.moduleCode] = module
         })
-        return modules
       })
-  }
-  async getOne(code: string): Promise<ModuleCondensed> {
-    if (this.codes.has(code)) {
-      return this.reduxState[code]
-      // return this.data[code]
-    } else {
-      return this.preload([code]).then((res) => res[0])
-    }
-  }
-  async getList(codes: string[]): Promise<ModuleCondensed[]> {
-    const toLoad = codes.filter((code) => !this.codes.has(code))
-    return this.preload(toLoad).then(() =>
-      codes.map((code) => this.reduxState[code])
-    )
   }
 }
 

--- a/apps/web/utils/modules-condensed-cache.ts
+++ b/apps/web/utils/modules-condensed-cache.ts
@@ -1,0 +1,39 @@
+import { ModuleCondensed } from '@modtree/entity'
+import { backend } from './backend'
+
+class ModuleCondensedCache {
+  private data: Record<string, ModuleCondensed>
+  private codes: Set<string>
+  constructor() {
+    this.data = {}
+    this.codes = new Set<string>()
+  }
+  async preload(codes: string[]): Promise<ModuleCondensed[]> {
+    const moduleCodes = codes.filter((code) => this.codes.has(code))
+    return backend
+      .get('/modules-condensed', {
+        params: { moduleCodes },
+      })
+      .then((res) => {
+        const modules: ModuleCondensed[] = res.data
+        modules.forEach((module) => {
+          this.codes.add(module.moduleCode)
+          this.data[module.moduleCode] = module
+        })
+        return modules
+      })
+  }
+  async getOne(code: string): Promise<ModuleCondensed> {
+    if (this.codes.has(code)) {
+      return this.data[code]
+    } else {
+      return this.preload([code]).then((res) => res[0])
+    }
+  }
+  async getList(codes: string[]): Promise<ModuleCondensed[]> {
+    const toLoad = codes.filter((code) => !this.codes.has(code))
+    return this.preload(toLoad).then(() => codes.map((code) => this.data[code]))
+  }
+}
+
+export const moduleCondensedCache = new ModuleCondensedCache()


### PR DESCRIPTION
> BREAKING: `GET /modules-condensed` will now return an empty array if `req.query.moduleCodes` is empty array. 
>
> Previously, it returns every module. Reason being that axios doesn't support sending empty arrays, and query params has only one legit data type (string).
>
> Axios will exclude `req.query.moduleCode` entirely if it's `[]`. So if the frontend requests with an empty array, the backend sees it as `undefined`.

### Summary of changes

- there exists a redux state to hold cached condensed modules
- `@/utils/modules-condensed-cache.ts` wraps this state with an async loader