### PR TITLE
feat(api): find by IDs for Degree and Graph

### DIFF
--- a/apps/server/src/api/degree.ts
+++ b/apps/server/src/api/degree.ts
@@ -1,6 +1,11 @@
 import { Api } from '@modtree/repo-api'
+import { CustomReqQuery } from '@modtree/types'
 import { copy, emptyInit, flatten } from '@modtree/utils'
 import { Request } from 'express'
+
+type DegreeIds = {
+  degreeIds: string[] | string
+}
 
 export class DegreeApi {
   /**
@@ -40,10 +45,15 @@ export class DegreeApi {
    *
    * @param {Api} api
    */
-  static list = (api: Api) => async () => {
-    return api.degreeRepo
-      .find({ relations: { modules: true } })
-      .then((results) => results.map((degree) => flatten.degree(degree)))
+  static list = (api: Api) => async (req: CustomReqQuery<DegreeIds>) => {
+    const degreeIds = req.query.degreeIds
+    if (Array.isArray(degreeIds)) {
+      return api.degreeRepo.findByIds(degreeIds)
+    } else if (degreeIds.length > 0) {
+      return api.degreeRepo.findByIds([degreeIds])
+    } else {
+      return []
+    }
   }
 
   /**

--- a/apps/server/src/api/graph.ts
+++ b/apps/server/src/api/graph.ts
@@ -9,6 +9,10 @@ type ListRequest = {
   email?: string
 }
 
+type GraphIds = {
+  graphIds: string[] | string
+}
+
 export class GraphApi {
   /**
    * creates a Graph
@@ -35,10 +39,15 @@ export class GraphApi {
    *
    * @param {Api} api
    */
-  static list = (api: Api) => async () => {
-    return api.graphRepo
-      .find({ relations: api.relations.graph })
-      .then((results) => results.map(flatten.graph))
+  static list = (api: Api) => async (req: CustomReqQuery<GraphIds>) => {
+    const graphIds = req.query.graphIds
+    if (Array.isArray(graphIds)) {
+      return api.graphRepo.findByIds(graphIds)
+    } else if (graphIds.length > 0) {
+      return api.graphRepo.findByIds([graphIds])
+    } else {
+      return []
+    }
   }
 
   /**

--- a/apps/server/src/api/module-condensed.ts
+++ b/apps/server/src/api/module-condensed.ts
@@ -4,7 +4,7 @@ import { Request } from 'express'
 import { Like } from 'typeorm'
 
 type ModuleCodes = {
-  moduleCodes: string[]
+  moduleCodes: string[] | string
 }
 
 export class ModuleCondensedApi {
@@ -14,8 +14,11 @@ export class ModuleCondensedApi {
    * @param {Api} api
    */
   static list = (api: Api) => (req: CustomReqQuery<ModuleCodes>) => {
-    if (Array.isArray(req.query.moduleCodes)) {
-      return api.moduleCondensedRepo.findByCodes(req.query.moduleCodes)
+    const moduleCodes = req.query.moduleCodes
+    if (Array.isArray(moduleCodes)) {
+      return api.moduleCondensedRepo.findByCodes(moduleCodes)
+    } else if (moduleCodes.length > 0) {
+      return api.moduleCondensedRepo.findByCodes([moduleCodes])
     } else {
       return []
     }

--- a/apps/server/test/degrees/[GET].test.ts
+++ b/apps/server/test/degrees/[GET].test.ts
@@ -11,29 +11,50 @@ const db = getSource(dbName)
 let app: Express
 let api: Api
 let find: jest.SpyInstance
+let findByIds: jest.SpyInstance
 
 beforeAll(() =>
   setup(db).then(() => {
     api = new Api(db)
     app = getApp(api)
     find = jest.spyOn(api.degreeRepo, 'find')
+    findByIds = jest.spyOn(api.degreeRepo, 'findByIds')
   })
 )
 beforeEach(() => jest.clearAllMocks())
 afterAll(() => teardown(db))
 
-const testRequest = async () => request(app).get('/degrees')
+const testRequest = () => request(app).get('/degrees')
 
-test('`find` is called once', async () => {
-  await testRequest()
-
-  expect(find).toBeCalledTimes(1)
+describe('without params', () => {
+  test('`find` is not called', async () => {
+    await testRequest()
+    expect(find).toBeCalledTimes(0)
+  })
 })
 
-test('`find` is called with correct args', async () => {
-  await testRequest()
+const withQueryRequest = () =>
+  request(app)
+    .get('/degrees')
+    .query({ degreeIds: ['10e3c552-fc7f-40b0-8af4-f0b171d4e041'] })
 
-  expect(find).toBeCalledWith({
-    relations: { modules: true },
+describe('with query params', () => {
+  /**
+   * findByIds actually calls find
+   */
+  test('`find` is called once', async () => {
+    await withQueryRequest()
+    expect(find).toBeCalledTimes(1)
+  })
+
+  test('`findByIds` is called once', async () => {
+    await withQueryRequest()
+    expect(findByIds).toBeCalledTimes(1)
+  })
+
+  test('`findByIds` is called with correct args', async () => {
+    await withQueryRequest()
+
+    expect(findByIds).toBeCalledWith(['10e3c552-fc7f-40b0-8af4-f0b171d4e041'])
   })
 })

--- a/apps/server/test/graphs/[GET].test.ts
+++ b/apps/server/test/graphs/[GET].test.ts
@@ -11,12 +11,14 @@ const db = getSource(dbName)
 let app: Express
 let api: Api
 let find: jest.SpyInstance
+let findByIds: jest.SpyInstance
 
 beforeAll(() =>
   setup(db).then(() => {
     api = new Api(db)
     app = getApp(api)
     find = jest.spyOn(api.graphRepo, 'find')
+    findByIds = jest.spyOn(api.graphRepo, 'findByIds')
   })
 )
 beforeEach(() => jest.clearAllMocks())
@@ -24,21 +26,35 @@ afterAll(() => teardown(db))
 
 const testRequest = () => request(app).get('/graphs')
 
-test('`find` is called once', async () => {
-  await testRequest()
-
-  expect(find).toBeCalledTimes(1)
+describe('without params', () => {
+  test('`find` is not called', async () => {
+    await testRequest()
+    expect(find).toBeCalledTimes(0)
+  })
 })
 
-test('`find` is called with correct args', async () => {
-  await testRequest()
+const withQueryRequest = () =>
+  request(app)
+    .get('/graphs')
+    .query({ graphIds: ['10e3c552-fc7f-40b0-8af4-f0b171d4e041'] })
 
-  expect(find).toBeCalledWith({
-    relations: {
-      user: true,
-      degree: true,
-      modulesPlaced: true,
-      modulesHidden: true,
-    },
+describe('with query params', () => {
+  /**
+   * findByIds actually calls find
+   */
+  test('`find` is called once', async () => {
+    await withQueryRequest()
+    expect(find).toBeCalledTimes(1)
+  })
+
+  test('`findByIds` is called once', async () => {
+    await withQueryRequest()
+    expect(findByIds).toBeCalledTimes(1)
+  })
+
+  test('`findByIds` is called with correct args', async () => {
+    await withQueryRequest()
+
+    expect(findByIds).toBeCalledWith(['10e3c552-fc7f-40b0-8af4-f0b171d4e041'])
   })
 })

--- a/apps/server/test/modules-condensed/[GET].test.ts
+++ b/apps/server/test/modules-condensed/[GET].test.ts
@@ -52,7 +52,7 @@ describe('with query params', () => {
     expect(findByCodes).toBeCalledTimes(1)
   })
 
-  test('`find` is called with correct args', async () => {
+  test('`findByCodes` is called with correct args', async () => {
     await withQueryRequest()
 
     expect(findByCodes).toBeCalledWith(['MA1100', 'MA2001'])


### PR DESCRIPTION
### Summary of changes

- Previously, calling `GET /modules-condensed` with 1 module in an array would return you 0 modules. This is fixed
- `GET /degrees` now supports array param. If not passed, returns 0 degrees.
- `GET /graphs` now supports array param. If not passed, returns 0 graphs.

### Testing

Server testing
