### PR TITLE
feat: unflatten API results

### DIFF
--- a/apps/server/src/api/degree.ts
+++ b/apps/server/src/api/degree.ts
@@ -1,6 +1,6 @@
 import { Api } from '@modtree/repo-api'
 import { CustomReqQuery } from '@modtree/types'
-import { copy, emptyInit, flatten } from '@modtree/utils'
+import { copy, emptyInit } from '@modtree/utils'
 import { Request } from 'express'
 
 type DegreeIds = {
@@ -16,7 +16,7 @@ export class DegreeApi {
   static create = (api: Api) => async (req: Request) => {
     const props = emptyInit.Degree
     copy(req.body, props)
-    return api.degreeRepo.initialize(props).then(flatten.degree)
+    return api.degreeRepo.initialize(props)
   }
 
   /**
@@ -25,7 +25,7 @@ export class DegreeApi {
    * @param {Api} api
    */
   static get = (api: Api) => async (req: Request) => {
-    return api.degreeRepo.findOneById(req.params.degreeId).then(flatten.degree)
+    return api.degreeRepo.findOneById(req.params.degreeId)
   }
 
   /**
@@ -65,6 +65,5 @@ export class DegreeApi {
     return api.degreeRepo
       .findOneById(req.params.degreeId)
       .then((degree) => api.degreeRepo.remove(degree))
-      .then(flatten.degree)
   }
 }

--- a/apps/server/src/api/graph.ts
+++ b/apps/server/src/api/graph.ts
@@ -1,6 +1,6 @@
 import { Api } from '@modtree/repo-api'
 import { CustomReqQuery } from '@modtree/types'
-import { copy, emptyInit, flatten } from '@modtree/utils'
+import { copy, emptyInit } from '@modtree/utils'
 import { Request } from 'express'
 
 type ListRequest = {
@@ -22,7 +22,7 @@ export class GraphApi {
   static create = (api: Api) => async (req: Request) => {
     const props = emptyInit.Graph
     copy(req.body, props)
-    return api.graphRepo.initialize(props).then(flatten.graph)
+    return api.graphRepo.initialize(props)
   }
 
   /**
@@ -31,7 +31,7 @@ export class GraphApi {
    * @param {Api} api
    */
   static get = (api: Api) => async (req: CustomReqQuery<ListRequest>) => {
-    return api.graphRepo.findOneById(req.params.graphId).then(flatten.graph)
+    return api.graphRepo.findOneById(req.params.graphId)
   }
 
   /**
@@ -71,7 +71,6 @@ export class GraphApi {
     return api.graphRepo
       .findOneById(graphId)
       .then((graph) => api.graphRepo.toggleModule(graph, moduleCode))
-      .then(flatten.graph)
   }
 
   /**
@@ -82,14 +81,11 @@ export class GraphApi {
   static updateFrontendProps = (api: Api) => async (req: Request) => {
     const { flowNodes, flowEdges } = req.body
     const { graphId } = req.params
-    return api.graphRepo
-      .findOneById(graphId)
-      .then((graph) =>
-        api.graphRepo.updateFrontendProps(graph, {
-          flowEdges,
-          flowNodes,
-        })
-      )
-      .then(flatten.graph)
+    return api.graphRepo.findOneById(graphId).then((graph) =>
+      api.graphRepo.updateFrontendProps(graph, {
+        flowEdges,
+        flowNodes,
+      })
+    )
   }
 }

--- a/apps/server/src/api/user.ts
+++ b/apps/server/src/api/user.ts
@@ -1,6 +1,6 @@
 import { Api } from '@modtree/repo-api'
 import { CustomReqBody, CustomReqQuery } from '@modtree/types'
-import { copy, emptyInit, flatten } from '@modtree/utils'
+import { copy, emptyInit } from '@modtree/utils'
 import { Request } from 'express'
 
 type ListRequest = {
@@ -18,7 +18,7 @@ export class UserApi {
   static create = (api: Api) => async (req: Request) => {
     const props = emptyInit.User
     copy(req.body, props)
-    return api.userRepo.initialize(props).then(flatten.user)
+    return api.userRepo.initialize(props)
   }
 
   /**
@@ -27,7 +27,7 @@ export class UserApi {
    * @param {Api} api
    */
   static get = (api: Api) => async (req: CustomReqQuery<ListRequest>) => {
-    return api.userRepo.findOneById(req.params.userId).then(flatten.user)
+    return api.userRepo.findOneById(req.params.userId)
   }
 
   /**
@@ -41,12 +41,10 @@ export class UserApi {
   static getByPrimaryKeys =
     (api: Api) => async (req: CustomReqBody<ListRequest>) => {
       const { id, authZeroId, email } = req.body
-      return api.userRepo
-        .findOneOrFail({
-          where: { id, authZeroId, email },
-          relations: api.relations.user,
-        })
-        .then(flatten.user)
+      return api.userRepo.findOneOrFail({
+        where: { id, authZeroId, email },
+        relations: api.relations.user,
+      })
     }
 
   /**
@@ -56,17 +54,15 @@ export class UserApi {
    */
   static list = (api: Api) => async (req: CustomReqQuery<ListRequest>) => {
     const { id, authZeroId, email } = req.query
-    return api.userRepo
-      .find({
-        where: { id, authZeroId, email },
-        relations: {
-          modulesDone: true,
-          modulesDoing: true,
-          savedDegrees: true,
-          savedGraphs: true,
-        },
-      })
-      .then((users) => users.map((u) => flatten.user(u)))
+    return api.userRepo.find({
+      where: { id, authZeroId, email },
+      relations: {
+        modulesDone: true,
+        modulesDoing: true,
+        savedDegrees: true,
+        savedGraphs: true,
+      },
+    })
   }
 
   /**
@@ -112,7 +108,6 @@ export class UserApi {
         relations: api.relations.user,
       })
       .then((user) => api.userRepo.insertDegrees(user, degreeIds))
-      .then(flatten.user)
   }
 
   /**
@@ -123,7 +118,7 @@ export class UserApi {
   static login = (api: Api) => async (req: Request) => {
     const authZeroId = req.params.authZeroId
     const { email } = req.body
-    return api.userLogin(authZeroId, email).then(flatten.user)
+    return api.userLogin(authZeroId, email)
   }
 
   /**
@@ -156,7 +151,6 @@ export class UserApi {
         relations: api.relations.user,
       })
       .then((user) => api.userRepo.insertGraphs(user, graphIds))
-      .then(flatten.user)
   }
 
   /**
@@ -175,7 +169,6 @@ export class UserApi {
         relations: api.relations.user,
       })
       .then((user) => api.userRepo.setMainDegree(user, degreeId))
-      .then(flatten.user)
   }
 
   /**
@@ -195,6 +188,5 @@ export class UserApi {
         relations: api.relations.user,
       })
       .then((user) => api.userRepo.setMainGraph(user, graphId))
-      .then(flatten.user)
   }
 }

--- a/apps/web/components/user-profile/degrees/add-new.tsx
+++ b/apps/web/components/user-profile/degrees/add-new.tsx
@@ -7,11 +7,11 @@ import { Row } from '@/ui/settings/lists/rows'
 import { Button } from '@/ui/buttons'
 import { SetState } from '@modtree/types'
 import { SettingsSearchBox } from '@/ui/search'
-import { ModuleCondensed } from '@modtree/entity'
+import { Module, ModuleCondensed } from '@modtree/entity'
 import { useAppDispatch, useAppSelector } from '@/store/redux'
 import { removeFromBuildList } from '@/store/search'
 
-function SelectedModules(props: { modules: ModuleCondensed[] }) {
+function SelectedModules(props: { modules: Module[] }) {
   const dispatch = useAppDispatch()
   return (
     <>

--- a/apps/web/components/user-profile/degrees/edit.tsx
+++ b/apps/web/components/user-profile/degrees/edit.tsx
@@ -22,17 +22,10 @@ export function Edit(props: { setPage: SetState<Pages['Degrees']> }) {
     const degree = backend
       .get<ModtreeApiResponse.Degree>(`/degree/${buildId}`)
       .then((res) => res.data)
-    degree
-      .then((degree) => {
-        console.log('fetched degree', degree)
-        return degree.modules
-      })
-      .then((moduleCodes) =>
-        backend.get(`/modules-condensed`, { params: { moduleCodes } })
-      )
-      .then((res) => {
-        dispatch(setBuildList(res.data))
-      })
+    degree.then((degree) => {
+      console.log('fetched degree', degree)
+      dispatch(setBuildList(degree.modules))
+    })
   }, [])
   return (
     <div className="flex flex-col">

--- a/apps/web/components/user-profile/degrees/main.tsx
+++ b/apps/web/components/user-profile/degrees/main.tsx
@@ -13,8 +13,8 @@ export function Main(props: {
 }) {
   const hasDegree = props.content.length !== 0
   const dispatch = useAppDispatch()
-  const degreeIds = useAppSelector((state) => state.user.savedDegrees)
-  const degreeCache = useAppSelector((state) => state.cache.degrees)
+  const degrees = useAppSelector((state) => state.user.savedDegrees)
+  //const degreeCache = useAppSelector((state) => state.cache.degrees)
   return (
     <div className="mb-12">
       <SettingsSection
@@ -26,8 +26,7 @@ export function Main(props: {
           <>
             <p>{text.degreeListSection.summary}</p>
             <div className="ui-rectangle flex flex-col overflow-hidden">
-              {degreeIds.map((degreeId, index) => {
-                const degree = degreeCache[degreeId]
+              {degrees.map((degree, index) => {
                 return (
                   <Row.Degree
                     key={dashed(degree.title, index)}

--- a/apps/web/components/user-profile/modules/add-doing.tsx
+++ b/apps/web/components/user-profile/modules/add-doing.tsx
@@ -19,7 +19,7 @@ export function AddDoing(props: { setPage: SetState<Pages['Modules']> }) {
       status: 'doing',
       moduleCodes: codes,
     })
-    dispatch(updateModulesDoing(codes))
+    dispatch(updateModulesDoing(buildList))
     props.setPage('main')
   }
   return (

--- a/apps/web/components/user-profile/modules/add-done.tsx
+++ b/apps/web/components/user-profile/modules/add-done.tsx
@@ -11,8 +11,7 @@ export function AddDone(props: { setPage: SetState<Pages['Modules']> }) {
   const dispatch = useAppDispatch()
   const buildList = useAppSelector((state) => state.search.buildList)
   function confirm() {
-    const codes = buildList.map((m) => m.moduleCode)
-    dispatch(updateModulesDone(codes))
+    dispatch(updateModulesDone(buildList))
     props.setPage('main')
   }
   return (

--- a/apps/web/components/user-profile/modules/main.tsx
+++ b/apps/web/components/user-profile/modules/main.tsx
@@ -6,20 +6,18 @@ import { dashed } from '@/utils/array'
 import { Row } from '@/ui/settings/lists/rows'
 import { useAppDispatch, useAppSelector } from '@/store/redux'
 import { setBuildList } from '@/store/search'
-import { useEffect } from 'react'
-import { moduleCondensedCache } from '@/utils/modules-condensed-cache'
 
 export function Main(props: { setPage: SetState<Pages['Modules']> }) {
   const dispatch = useAppDispatch()
   const user = useAppSelector((state) => state.user)
-  const cache = useAppSelector((state) => state.cache.modulesCondensed)
+  //const cache = useAppSelector((state) => state.cache.modulesCondensed)
 
   /**
    * update the cache with required modules
    */
-  //   useEffect(() => {
-  //     moduleCondensedCache.load([...user.modulesDone, ...user.modulesDoing])
-  //   }, [user.modulesDone, user.modulesDoing])
+  // useEffect(() => {
+  //   moduleCondensedCache.load([...user.modulesDone, ...user.modulesDoing])
+  // }, [user.modulesDone, user.modulesDoing])
 
   const hasModules = {
     done: user.modulesDone.length !== 0,

--- a/apps/web/components/user-profile/modules/main.tsx
+++ b/apps/web/components/user-profile/modules/main.tsx
@@ -17,9 +17,9 @@ export function Main(props: { setPage: SetState<Pages['Modules']> }) {
   /**
    * update the cache with required modules
    */
-  useEffect(() => {
-    moduleCondensedCache.load([...user.modulesDone, ...user.modulesDoing])
-  }, [user.modulesDone, user.modulesDoing])
+  //   useEffect(() => {
+  //     moduleCondensedCache.load([...user.modulesDone, ...user.modulesDoing])
+  //   }, [user.modulesDone, user.modulesDoing])
 
   const hasModules = {
     done: user.modulesDone.length !== 0,
@@ -33,7 +33,7 @@ export function Main(props: { setPage: SetState<Pages['Modules']> }) {
           addButtonColor={hasModules.doing ? 'gray' : 'green'}
           addButtonText={hasModules.doing ? 'Modify' : 'Add doing'}
           onAddClick={() => {
-            dispatch(setBuildList(user.modulesDoing.map((code) => cache[code])))
+            dispatch(setBuildList(user.modulesDoing))
             props.setPage('add-doing')
           }}
         >
@@ -41,11 +41,11 @@ export function Main(props: { setPage: SetState<Pages['Modules']> }) {
             <>
               <p>{text.moduleListSection.doing.summary}</p>
               <div className="ui-rectangle flex flex-col overflow-hidden">
-                {user.modulesDoing.map((code, index) => (
-                  <Row.Module key={dashed(code, index)}>
-                    <span className="font-semibold">{code}</span>
+                {user.modulesDoing.map((module, index) => (
+                  <Row.Module key={dashed(module.moduleCode, index)}>
+                    <span className="font-semibold">{module.moduleCode}</span>
                     <span className="mx-1">/</span>
-                    {cache[code]?.title}
+                    {module.title}
                   </Row.Module>
                 ))}
               </div>
@@ -61,7 +61,7 @@ export function Main(props: { setPage: SetState<Pages['Modules']> }) {
           addButtonColor={hasModules.done ? 'gray' : 'green'}
           addButtonText={hasModules.done ? 'Modify' : 'Add done'}
           onAddClick={() => {
-            dispatch(setBuildList(user.modulesDone.map((code) => cache[code])))
+            dispatch(setBuildList(user.modulesDone))
             props.setPage('add-done')
           }}
         >
@@ -69,11 +69,11 @@ export function Main(props: { setPage: SetState<Pages['Modules']> }) {
             <>
               <p>{text.moduleListSection.done.summary}</p>
               <div className="ui-rectangle flex flex-col overflow-hidden">
-                {user.modulesDone.map((code, index) => (
-                  <Row.Module key={dashed(code, index)}>
-                    <span className="font-semibold">{code}</span>
+                {user.modulesDone.map((module, index) => (
+                  <Row.Module key={dashed(module.moduleCode, index)}>
+                    <span className="font-semibold">{module.moduleCode}</span>
                     <span className="mx-1">/</span>
-                    {cache[code]?.title}
+                    {module.title}
                   </Row.Module>
                 ))}
               </div>

--- a/apps/web/components/user-profile/modules/selected-modules.tsx
+++ b/apps/web/components/user-profile/modules/selected-modules.tsx
@@ -2,9 +2,9 @@ import { useAppDispatch } from '@/store/redux'
 import { removeFromBuildList } from '@/store/search'
 import { dashed } from '@/utils/array'
 import { Row } from '@/ui/settings/lists/rows'
-import { ModuleCondensed } from '@modtree/entity'
+import { Module } from '@modtree/entity'
 
-export function SelectedModules(props: { modules: ModuleCondensed[] }) {
+export function SelectedModules(props: { modules: Module[] }) {
   const dispatch = useAppDispatch()
   return (
     <>

--- a/apps/web/store/search.ts
+++ b/apps/web/store/search.ts
@@ -31,16 +31,16 @@ export const search = createSlice({
     clearBuildList: (state) => {
       state.buildList = []
     },
-    setBuildList: (state, action: PayloadAction<ModuleCondensed[]>) => {
+    setBuildList: (state, action: PayloadAction<Module[]>) => {
       state.buildList = action.payload
     },
-    addToBuildList: (state, action: PayloadAction<ModuleCondensed>) => {
+    addToBuildList: (state, action: PayloadAction<Module>) => {
       const codes = new Set(state.buildList.map((m) => m.moduleCode))
       if (!codes.has(action.payload.moduleCode)) {
         state.buildList = [...state.buildList, action.payload]
       }
     },
-    removeFromBuildList: (state, action: PayloadAction<ModuleCondensed>) => {
+    removeFromBuildList: (state, action: PayloadAction<Module>) => {
       const codes = new Set(state.buildList.map((m) => m.moduleCode))
       if (codes.has(action.payload.moduleCode)) {
         state.buildList = state.buildList.filter(

--- a/apps/web/store/types.d.ts
+++ b/apps/web/store/types.d.ts
@@ -1,6 +1,7 @@
 import { Pages } from '@/types'
 import { Module, ModuleCondensed } from '@modtree/entity'
 import { ModtreeApiResponse } from '@modtree/types'
+import { EmptyResponseProps } from '@modtree/utils'
 
 export type ModuleCondensedMap = {
   [key: string]: ModuleCondensed
@@ -12,12 +13,22 @@ export type ContextMenuProps = {
   menu: 'pane' | 'node'
 }
 
+// temporarily add EmptyResponseProps because
+// ModtreeApiResponse and EmptyResponseProps are different.
+//
+// they are different because ModtreeApiResponse expects full entity
+// but EmptyResponseProps expects flattened entity
+
 export type ReduxState = {
-  user: ModtreeApiResponse.User
+  user: ModtreeApiResponse.User | EmptyResponseProps['User']
   degree: ModtreeApiResponse.Degree
-  graph: ModtreeApiResponse.Graph & {
-    selectedCodes: string[]
-  }
+  graph:
+    | (ModtreeApiResponse.Graph & {
+        selectedCodes: string[]
+      })
+    | (EmptyResponseProps['Graph'] & {
+        selectedCodes: string[]
+      })
   modal: {
     userProfilePage: Pages['UserProfile']
     showUserProfile: boolean

--- a/apps/web/store/types.d.ts
+++ b/apps/web/store/types.d.ts
@@ -35,7 +35,7 @@ export type ReduxState = {
   search: {
     buildId: string
     buildTitle: string
-    buildList: ModuleCondensed[]
+    buildList: Module[]
     searchResults: ModuleCondensed[]
     module: Module[]
     hasResults: boolean

--- a/apps/web/store/user.ts
+++ b/apps/web/store/user.ts
@@ -1,3 +1,4 @@
+import { Module } from '@modtree/entity'
 import { ModtreeApiResponse } from '@modtree/types'
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { baseInitialState } from './initial-state'
@@ -6,10 +7,10 @@ export const user = createSlice({
   name: 'user',
   initialState: baseInitialState.user,
   reducers: {
-    updateModulesDone: (user, action: PayloadAction<string[]>) => {
+    updateModulesDone: (user, action: PayloadAction<Module[]>) => {
       user.modulesDone = action.payload
     },
-    updateModulesDoing: (user, action: PayloadAction<string[]>) => {
+    updateModulesDoing: (user, action: PayloadAction<Module[]>) => {
       user.modulesDoing = action.payload
     },
     setUser: (user, action: PayloadAction<ModtreeApiResponse.User>) => {

--- a/apps/web/ui/search/index.tsx
+++ b/apps/web/ui/search/index.tsx
@@ -3,29 +3,25 @@ import { useAppDispatch } from '@/store/redux'
 import {
   addToBuildList,
   clearSearches,
-  setSearchedModuleCondensed,
+  setSearchedModule,
 } from '@/store/search'
 import { SearchContainer } from './container'
 import { SearchResultContainer } from './results'
 import { flatten } from '@/utils/tailwind'
-import { ModuleCondensed } from '@modtree/entity'
+import { Module } from '@modtree/entity'
 import { getModuleInfo } from '@/utils/backend'
+import { EmptyResponse } from '@modtree/utils'
 
-const emptyModuleCondensed: ModuleCondensed = {
-  title: '',
-  id: '',
-  moduleCode: '',
-  moduleLevel: 0,
-}
+const emptyModule: Module = EmptyResponse.Module
 
 export function RootSearchBox() {
   const dispatch = useAppDispatch()
   /**
    * only changes upon clicking on the search result
    */
-  const selectState = useState(emptyModuleCondensed)
+  const selectState = useState(emptyModule)
 
-  const onSelect = (query: ModuleCondensed) => {
+  const onSelect = (query: Module) => {
     selectState[1](query)
     getModuleInfo(dispatch, query.moduleCode)
   }
@@ -34,7 +30,7 @@ export function RootSearchBox() {
     <div className="fixed top-3 left-3 w-72 z-10">
       <SearchContainer
         resultsComponent={SearchResultContainer}
-        set={setSearchedModuleCondensed}
+        set={setSearchedModule}
         clear={clearSearches}
         selectState={selectState}
         onSelect={onSelect}
@@ -51,9 +47,9 @@ export function SettingsSearchBox() {
   /**
    * only changes upon clicking on the search result
    */
-  const selectState = useState(emptyModuleCondensed)
+  const selectState = useState(emptyModule)
 
-  const onSelect = (query: ModuleCondensed) => {
+  const onSelect = (query: Module) => {
     selectState[1](query)
     dispatch(addToBuildList(query))
   }
@@ -69,7 +65,7 @@ export function SettingsSearchBox() {
     >
       <SearchContainer
         resultsComponent={SearchResultContainer}
-        set={setSearchedModuleCondensed}
+        set={setSearchedModule}
         clear={clearSearches}
         selectState={selectState}
         onSelect={onSelect}

--- a/libs/repo-user/src/index.ts
+++ b/libs/repo-user/src/index.ts
@@ -260,7 +260,6 @@ export class UserRepository
         relations: this.graphRelations,
       })
       .then((graph) => {
-        console.log(graph)
         // if the graph is not in saved
         const savedGraphIds = user.savedGraphs.map((graph) => graph.id)
         if (!savedGraphIds.includes(graphId)) {

--- a/libs/types/src/api-response.ts
+++ b/libs/types/src/api-response.ts
@@ -5,45 +5,10 @@ import {
   IModule,
   IModuleCondensed,
 } from './entity-interface'
-import { Modify } from './utils'
 
-/**
- * User API respsonse
- */
-export type User = Modify<
-  IUser,
-  {
-    modulesDone: IModule[]
-    modulesDoing: IModule[]
-    savedDegrees: IDegree[]
-    savedGraphs: IGraph[]
-    mainDegree: IDegree
-    mainGraph: IGraph
-  }
->
-
-/**
- * Degree API respsonse
- */
-export type Degree = Modify<
-  IDegree,
-  {
-    modules: IModule[]
-  }
->
-
-/**
- * Graph API respsonse
- */
-export type Graph = Modify<
-  IGraph,
-  {
-    user: IUser
-    degree: IDegree
-    modulesPlaced: IModule[]
-    modulesHidden: IModule[]
-  }
->
+export type User = IUser
+export type Degree = IDegree
+export type Graph = IGraph
 
 /**
  * already-flat entities

--- a/libs/types/src/api-response.ts
+++ b/libs/types/src/api-response.ts
@@ -13,12 +13,12 @@ import { Modify } from './utils'
 export type User = Modify<
   IUser,
   {
-    modulesDone: string[]
-    modulesDoing: string[]
-    savedDegrees: string[]
-    savedGraphs: string[]
-    mainDegree: string
-    mainGraph: string
+    modulesDone: IModule[]
+    modulesDoing: IModule[]
+    savedDegrees: IDegree[]
+    savedGraphs: IGraph[]
+    mainDegree: IDegree
+    mainGraph: IGraph
   }
 >
 

--- a/libs/types/src/api-response.ts
+++ b/libs/types/src/api-response.ts
@@ -28,7 +28,7 @@ export type User = Modify<
 export type Degree = Modify<
   IDegree,
   {
-    modules: string[]
+    modules: IModule[]
   }
 >
 

--- a/libs/types/src/api-response.ts
+++ b/libs/types/src/api-response.ts
@@ -38,10 +38,10 @@ export type Degree = Modify<
 export type Graph = Modify<
   IGraph,
   {
-    user: string
-    degree: string
-    modulesPlaced: string[]
-    modulesHidden: string[]
+    user: IUser
+    degree: IDegree
+    modulesPlaced: IModule[]
+    modulesHidden: IModule[]
   }
 >
 

--- a/libs/utils/src/empty.ts
+++ b/libs/utils/src/empty.ts
@@ -3,9 +3,7 @@ import {
   InitProps,
   Modify,
   IGraph,
-  IDegree,
   IUser,
-  IModule,
 } from '@modtree/types'
 
 /** empty init props */

--- a/libs/utils/src/empty.ts
+++ b/libs/utils/src/empty.ts
@@ -93,7 +93,17 @@ export const emptyInit: InitProps = {
 }
 
 type EmptyResponseProps = {
-  User: ModtreeApiResponse.User
+  User: Modify<
+    IUser,
+    {
+      modulesDone: string[]
+      modulesDoing: string[]
+      savedDegrees: string[]
+      savedGraphs: string[]
+      mainDegree: string
+      mainGraph: string
+    }
+  >
   Degree: ModtreeApiResponse.Degree
   Module: ModtreeApiResponse.Module
   Graph: Modify<

--- a/libs/utils/src/empty.ts
+++ b/libs/utils/src/empty.ts
@@ -1,4 +1,12 @@
-import { ModtreeApiResponse, InitProps } from '@modtree/types'
+import {
+  ModtreeApiResponse,
+  InitProps,
+  Modify,
+  IGraph,
+  IDegree,
+  IUser,
+  IModule,
+} from '@modtree/types'
 
 /** empty init props */
 export const emptyInit: InitProps = {
@@ -88,7 +96,15 @@ type EmptyResponseProps = {
   User: ModtreeApiResponse.User
   Degree: ModtreeApiResponse.Degree
   Module: ModtreeApiResponse.Module
-  Graph: ModtreeApiResponse.Graph
+  Graph: Modify<
+    IGraph,
+    {
+      user: string
+      degree: string
+      modulesPlaced: string[]
+      modulesHidden: string[]
+    }
+  >
   ModuleCondensed: ModtreeApiResponse.ModuleCondensed
 }
 

--- a/libs/utils/src/empty.ts
+++ b/libs/utils/src/empty.ts
@@ -92,6 +92,13 @@ export const emptyInit: InitProps = {
   },
 }
 
+/**
+ * In the modified types, arrays take the actual entity type to
+ * follow the redux types in the frontend.
+ *
+ * We don't want things like `Module[] | string[]` because TypeScript
+ * will only allow you to do things that apply to both possible types.
+ */
 export type EmptyResponseProps = {
   User: Modify<
     IUser,
@@ -111,8 +118,8 @@ export type EmptyResponseProps = {
     {
       user: string
       degree: string
-      modulesPlaced: string[]
-      modulesHidden: string[]
+      modulesPlaced: IModule[]
+      modulesHidden: IModule[]
     }
   >
   ModuleCondensed: ModtreeApiResponse.ModuleCondensed

--- a/libs/utils/src/empty.ts
+++ b/libs/utils/src/empty.ts
@@ -4,6 +4,8 @@ import {
   Modify,
   IGraph,
   IUser,
+  IModule,
+  IDegree,
 } from '@modtree/types'
 
 /** empty init props */
@@ -90,14 +92,14 @@ export const emptyInit: InitProps = {
   },
 }
 
-type EmptyResponseProps = {
+export type EmptyResponseProps = {
   User: Modify<
     IUser,
     {
-      modulesDone: string[]
-      modulesDoing: string[]
-      savedDegrees: string[]
-      savedGraphs: string[]
+      modulesDone: IModule[]
+      modulesDoing: IModule[]
+      savedDegrees: IDegree[]
+      savedGraphs: IGraph[]
       mainDegree: string
       mainGraph: string
     }

--- a/libs/utils/src/entity/index.ts
+++ b/libs/utils/src/entity/index.ts
@@ -41,9 +41,8 @@ export const flatten = {
    * flattens a graph to response shape
    *
    * @param {Graph} graph
-   * @returns {ModtreeApiResponse.Graph}
    */
-  graph(graph: Graph): ModtreeApiResponse.Graph {
+  graph(graph: Graph) {
     return {
       ...graph,
       id: graph.id,

--- a/libs/utils/src/entity/index.ts
+++ b/libs/utils/src/entity/index.ts
@@ -58,9 +58,8 @@ export const flatten = {
    * flattens a degree to response shape
    *
    * @param {Degree} degree
-   * @returns {ModtreeApiResponse.Degree}
    */
-  degree(degree: Degree): ModtreeApiResponse.Degree {
+  degree(degree: Degree) {
     return { ...degree, modules: degree.modules.map(flatten.module) }
   },
 }

--- a/libs/utils/src/entity/index.ts
+++ b/libs/utils/src/entity/index.ts
@@ -21,9 +21,8 @@ export const flatten = {
    * flattens a user to response shape
    *
    * @param {User} user
-   * @returns {ModtreeApiResponse.User}
    */
-  user(user: User): ModtreeApiResponse.User {
+  user(user: User) {
     return {
       ...user,
       modulesDoing: user.modulesDoing.map(flatten.module),


### PR DESCRIPTION
### Summary of changes

- All API endpoints return unflattened entities
- Updated some redux types
- The type `ModtreeApiResponse.{Entity}` is the type `{Entity}`
- `EmptyResponseProps` are still flattened types

### Testing

- Ensure that frontend still works the same way
