### PR TITLE
feat: add port reading to .env

### DIFF
--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -1,4 +1,4 @@
-import { db } from '@modtree/typeorm-config'
+import { defaultConfig, readEnv, readJson } from '@modtree/typeorm-config'
 import { getApp } from './app'
 import { DataSource, Repository } from 'typeorm'
 import { Api } from '@modtree/repo-api'
@@ -23,9 +23,17 @@ function checkhealth(db: DataSource) {
   })
 }
 
+function getConfig() {
+  const config = defaultConfig
+  readJson(config)
+  readEnv(config)
+  return new DataSource(config)
+}
+
 console.debug('Initializing connection to database...')
-db.initialize()
-  .then(async () => {
+getConfig()
+  .initialize()
+  .then(async (db) => {
     console.debug(
       `Connection to database [${db.options.database}] established.`
     )

--- a/libs/typeorm-config/src/index.ts
+++ b/libs/typeorm-config/src/index.ts
@@ -68,11 +68,13 @@ export function readEnv(target: DataSourceOptions) {
     username: prefix('USERNAME'),
     password: prefix('PASSWORD'),
     host: prefix('HOST'),
+    port: parseInt(prefix('PORT') || '5432'),
     database: prefix('ACTIVE_DATABASE'),
   }
   if (env.username) target.username = env.username
   if (env.password) target.password = env.password
   if (env.host) target.host = env.host
+  if (env.port) target.port = env.port
   if (env.database) target.database = env.database
   /**
    * for postgres deployments

--- a/libs/typeorm-config/src/index.ts
+++ b/libs/typeorm-config/src/index.ts
@@ -62,7 +62,7 @@ export function readJson(target: DataSourceOptions) {
  * }
  * ```
  */
-function readEnv(target: DataSourceOptions) {
+export function readEnv(target: DataSourceOptions) {
   const prefix = (e: string): string | undefined => process.env[getPrefix() + e]
   const env: Partial<DataSourceOptions> = {
     username: prefix('USERNAME'),
@@ -86,7 +86,7 @@ function readEnv(target: DataSourceOptions) {
   }
 }
 
-const defaultConfig: DataSourceOptions = {
+export const defaultConfig: DataSourceOptions = {
   type: 'postgres',
   rootDir: join(__dirname, '../../..'),
   entities: [ModuleCondensed, Module, User, Degree, Graph, ModuleFull],

--- a/libs/typeorm-config/src/index.ts
+++ b/libs/typeorm-config/src/index.ts
@@ -21,7 +21,7 @@ import { join } from 'path'
  *
  * NODE_ENV decides which key of that JSON is read.
  */
-function readJson(target: DataSourceOptions) {
+export function readJson(target: DataSourceOptions) {
   /**
    * do nothing if there's no NODE_ENV
    */
@@ -86,25 +86,27 @@ function readEnv(target: DataSourceOptions) {
   }
 }
 
+const defaultConfig: DataSourceOptions = {
+  type: 'postgres',
+  rootDir: join(__dirname, '../../..'),
+  entities: [ModuleCondensed, Module, User, Degree, Graph, ModuleFull],
+  migrations: [],
+  username: '',
+  password: '',
+  host: 'localhost',
+  database: 'mt_test',
+  restoreSource: 'mod3.sql',
+  synchronize: true,
+  migrationsRun: false,
+}
+
 /**
  * generate a config based on the database type
  *
  * @returns {DataSourceOptions}
  */
-function getConfig(): DataSourceOptions {
-  const base: DataSourceOptions = {
-    type: 'postgres',
-    rootDir: join(__dirname, '../../..'),
-    entities: [ModuleCondensed, Module, User, Degree, Graph, ModuleFull],
-    migrations: [],
-    username: '',
-    password: '',
-    host: 'localhost',
-    database: 'mt_test',
-    restoreSource: 'mod3.sql',
-    synchronize: true,
-    migrationsRun: false,
-  }
+export function getConfig(): DataSourceOptions {
+  const base = defaultConfig
   readJson(base)
   readEnv(base)
   return base

--- a/libs/typeorm-config/src/index.ts
+++ b/libs/typeorm-config/src/index.ts
@@ -64,17 +64,19 @@ export function readJson(target: DataSourceOptions) {
  */
 export function readEnv(target: DataSourceOptions) {
   const prefix = (e: string): string | undefined => process.env[getPrefix() + e]
+  let activeDatabase = prefix('ACTIVE_DATABASE')
   const env: Partial<DataSourceOptions> = {
     username: prefix('USERNAME'),
     password: prefix('PASSWORD'),
     host: prefix('HOST'),
     port: parseInt(prefix('PORT') || '5432'),
-    database: prefix('ACTIVE_DATABASE'),
+    database: prefix('DATABASE'),
   }
   if (env.username) target.username = env.username
   if (env.password) target.password = env.password
   if (env.host) target.host = env.host
   if (env.port) target.port = env.port
+  if (activeDatabase) target.database = activeDatabase
   if (env.database) target.database = env.database
   /**
    * for postgres deployments

--- a/libs/typeorm-config/test/config.test.ts
+++ b/libs/typeorm-config/test/config.test.ts
@@ -1,0 +1,36 @@
+import { DataSourceOptions } from '@modtree/types'
+import { getConfig } from '../src'
+import fs from 'fs'
+
+let config: DataSourceOptions
+let rootFiles: string[]
+
+test('reads correct files', () => {
+  expect(1).toBe(1)
+})
+
+test('returns an object', () => {
+  config = getConfig()
+  expect(config).toBeDefined()
+  expect(config).toBeInstanceOf(Object)
+})
+
+test('root directory is correct', () => {
+  rootFiles = fs.readdirSync(config.rootDir)
+  expect(rootFiles).toEqual(
+    expect.arrayContaining([
+      'nx.json',
+      'workspace.json',
+      'package.json',
+      'tsconfig.base.json',
+    ])
+  )
+})
+
+test('there is a modtree.config.json', () => {
+  expect(rootFiles).toContainEqual('modtree.config.json')
+})
+
+test('NODE_ENV is test', () => {
+  expect(process.env['NODE_ENV']).toEqual('test')
+})

--- a/scripts/yarn.sh
+++ b/scripts/yarn.sh
@@ -34,6 +34,7 @@ weiseng_inv() {
 khang_env() {
   ln -sf $SRC/web/.env.local $WEB/.env.local
   ln -sf $SRC/admin.config.json ./admin.config.json
+  ln -sf $SRC/server/.env ./.env
 }
 
 khang_inv() {

--- a/scripts/yarn.sh
+++ b/scripts/yarn.sh
@@ -32,8 +32,8 @@ weiseng_inv() {
 # khang's config
 
 khang_env() {
-  ln -sf $SRC/web/.env.local $WEB/.env.local
-  ln -sf $SRC/admin.config.json ./admin.config.json
+  # ln -sf $SRC/web/.env.local $WEB/.env.local
+  # ln -sf $SRC/admin.config.json ./admin.config.json
   ln -sf $SRC/server/.env ./.env
 }
 


### PR DESCRIPTION
### Summary of changes

- server is bundled with webpack, and sent to `dist` at root.
- since json configs are read from relative paths, they will not get read at all.
- but .env files are still read, somehow
so now frontend authenticates properly with server given this `.env` at workspace root:
```
POSTGRES_DATABASE=web
POSTGRES_USERNAME=web
POSTGRES_PASSWORD=web
POSTGRES_HOST=localhost
POSTGRES_PORT=4000

TEST_POSTGRES_DATABASE=test
TEST_POSTGRES_USERNAME=test
TEST_POSTGRES_PASSWORD=test
TEST_POSTGRES_HOST=localhost
TEST_POSTGRES_PORT=4001

```

### Testing

- Mutate the given .env params and the connection should be denied.
