### PR TITLE
fix: only run auto-docs when server is running

### DIFF
--- a/libs/auto-docs/test/setup.test.ts
+++ b/libs/auto-docs/test/setup.test.ts
@@ -30,182 +30,193 @@ beforeAll(() =>
   })
 )
 
-describe('bare minimum', () => {
-  test('runs with no errors', async () => {
-    const res = await api.autoSetup(init)
-    u1 = res.u1
-    u2 = res.u2
-    d1 = res.d1
-    d2 = res.d2
-    g1 = res.g1
-    g2 = res.g2
-    expect(1).toEqual(1)
-  })
+let serverRunning = false
 
-  test('has 2 users', async () => {
-    await Repo.User.count().then((count) => {
-      expect(count).toEqual(2)
-    })
-  })
-
-  test('has 2 degrees', async () => {
-    await Repo.Degree.count().then((count) => {
-      expect(count).toEqual(2)
-    })
-  })
-
-  test('has 2 graphs', async () => {
-    await Repo.Graph.count().then((count) => {
-      expect(count).toEqual(2)
-    })
-  })
+test('server is running', async () => {
+  const res = await postman.get('/')
+  expect(res.status).toEqual(200)
+  expect(res.data).toEqual('modtree server is running')
+  serverRunning = true
 })
 
-describe('properties checks', () => {
-  let userKeys: string[]
-  let degreeKeys: string[]
-  let graphKeys: string[]
+if (serverRunning) {
+  describe('bare minimum', () => {
+    test('runs with no errors', async () => {
+      const res = await api.autoSetup(init)
+      u1 = res.u1
+      u2 = res.u2
+      d1 = res.d1
+      d2 = res.d2
+      g1 = res.g1
+      g2 = res.g2
+      expect(1).toEqual(1)
+    })
 
-  test('get keys', () => {
-    userKeys = Object.keys(Repo.User.metadata.propertiesMap)
-    degreeKeys = Object.keys(Repo.Degree.metadata.propertiesMap)
-    graphKeys = Object.keys(Repo.Graph.metadata.propertiesMap)
-    expect(1).toEqual(1)
-  })
+    test('has 2 users', async () => {
+      await Repo.User.count().then((count) => {
+        expect(count).toEqual(2)
+      })
+    })
 
-  test('all properties exist', () => {
-    expect(Object.keys(u1)).toIncludeSameMembers(userKeys)
-    expect(Object.keys(u2)).toIncludeSameMembers(userKeys)
-    expect(Object.keys(d1)).toIncludeSameMembers(degreeKeys)
-    expect(Object.keys(d2)).toIncludeSameMembers(degreeKeys)
-    expect(Object.keys(g1)).toIncludeSameMembers(graphKeys)
-    expect(Object.keys(g2)).toIncludeSameMembers(graphKeys)
-  })
+    test('has 2 degrees', async () => {
+      await Repo.Degree.count().then((count) => {
+        expect(count).toEqual(2)
+      })
+    })
 
-  test('user array properties have at least one child', () => {
-    ;[u1, u2].forEach((one) => {
-      Object.entries(one).forEach(([_, value]) => {
-        if (Array.isArray(value)) expect(value.length).toBeGreaterThan(0)
+    test('has 2 graphs', async () => {
+      await Repo.Graph.count().then((count) => {
+        expect(count).toEqual(2)
       })
     })
   })
 
-  test('degree array properties have at least one child', () => {
-    ;[d1, d2].forEach((one) => {
-      Object.entries(one).forEach(([_, value]) => {
-        if (Array.isArray(value)) expect(value.length).toBeGreaterThan(0)
+  describe('properties checks', () => {
+    let userKeys: string[]
+    let degreeKeys: string[]
+    let graphKeys: string[]
+
+    test('get keys', () => {
+      userKeys = Object.keys(Repo.User.metadata.propertiesMap)
+      degreeKeys = Object.keys(Repo.Degree.metadata.propertiesMap)
+      graphKeys = Object.keys(Repo.Graph.metadata.propertiesMap)
+      expect(1).toEqual(1)
+    })
+
+    test('all properties exist', () => {
+      expect(Object.keys(u1)).toIncludeSameMembers(userKeys)
+      expect(Object.keys(u2)).toIncludeSameMembers(userKeys)
+      expect(Object.keys(d1)).toIncludeSameMembers(degreeKeys)
+      expect(Object.keys(d2)).toIncludeSameMembers(degreeKeys)
+      expect(Object.keys(g1)).toIncludeSameMembers(graphKeys)
+      expect(Object.keys(g2)).toIncludeSameMembers(graphKeys)
+    })
+
+    test('user array properties have at least one child', () => {
+      ;[u1, u2].forEach((one) => {
+        Object.entries(one).forEach(([_, value]) => {
+          if (Array.isArray(value)) expect(value.length).toBeGreaterThan(0)
+        })
+      })
+    })
+
+    test('degree array properties have at least one child', () => {
+      ;[d1, d2].forEach((one) => {
+        Object.entries(one).forEach(([_, value]) => {
+          if (Array.isArray(value)) expect(value.length).toBeGreaterThan(0)
+        })
+      })
+    })
+
+    test('graph array properties have at least one child', () => {
+      ;[g1, g2].forEach((one) => {
+        Object.entries(one).forEach(([_, value]) => {
+          if (Array.isArray(value)) expect(value.length).toBeGreaterThan(0)
+        })
       })
     })
   })
 
-  test('graph array properties have at least one child', () => {
-    ;[g1, g2].forEach((one) => {
-      Object.entries(one).forEach(([_, value]) => {
-        if (Array.isArray(value)) expect(value.length).toBeGreaterThan(0)
-      })
+  describe('samples', () => {
+    const all: any[] = []
+
+    // Map routes into Jest requirements
+    const tests: JestEach[] = routes.map((r) => [
+      r.method,
+      r.route,
+      {
+        url: r.url,
+        params: r.params,
+      },
+    ])
+
+    // In the tests, there is a single POST test per entity,
+    // that creates a new object.
+    //
+    // After this POST test and before the next POST test,
+    // there is most likely a DELETE test. In order to prevent side-effects,
+    // such as cascade deleting, or having to clear relations, the
+    // DELETE test will be performed on the newly POSTed object.
+    //
+    // This ID saves that ID for future use for DELETE.
+    let id: string
+
+    test.each(tests)('%p %p', async (method, route, routeInfo) => {
+      // 1. Prepare request
+
+      // ---- unpack data
+      let url = routeInfo.url || route
+      const params = routeInfo.params
+
+      // ---- fill in path params if required
+      if (method === 'delete') {
+        url = url.replaceAll(':userId', id)
+        url = url.replaceAll(':degreeId', id)
+        url = url.replaceAll(':graphId', id)
+      } else {
+        url = url.replaceAll(':userId', u1.id)
+        url = url.replaceAll(':degreeId', d1.id)
+        url = url.replaceAll(':graphId', g1.id)
+        url = url.replaceAll(':authZeroId', u1.authZeroId)
+      }
+
+      // ---- fill in query params if required
+      if (params) {
+        if (params.hasOwnProperty('degreeIds')) {
+          // used in:
+          // - degree list
+          // - user add degree
+          params['degreeIds'].push(d2.id)
+        }
+        if (params.hasOwnProperty('graphIds')) {
+          // used in:
+          // - user add graph
+          params['graphIds'].push(g2.id)
+        }
+        if (params.hasOwnProperty('degreeId')) {
+          // used in:
+          // - user set main degree
+          params['degreeId'] = d2.id
+        }
+        if (params.hasOwnProperty('graphId')) {
+          // used in:
+          // - user set main graph
+          params['graphId'] = g2.id
+        }
+        if (method === 'post' && route === '/graph') {
+          // used in:
+          // - create graph
+          params['userId'] = u1.id
+          params['degreeId'] = d1.id
+        }
+      }
+
+      // 2. Make request
+      const res = await postman.send(method, url, params)
+
+      // 3. Transform data
+      const data = {
+        method: res.config.method,
+        url: res.config.url,
+        res: res.data,
+      }
+
+      all.push(data)
+
+      // 4. Save ID if created new entity
+      if (isEntityCreation(method, route)) {
+        id = res.data.id
+      }
+
+      expect(1).toEqual(1)
+    })
+
+    test('write to file', () => {
+      const rootDir = join(__dirname, '../../..')
+      const json = JSON.stringify(all, null, 2)
+      fs.writeFileSync(join(rootDir, 'references/api.json'), json)
+
+      expect(1).toEqual(1)
     })
   })
-})
-
-describe('samples', () => {
-  const all: any[] = []
-
-  // Map routes into Jest requirements
-  const tests: JestEach[] = routes.map((r) => [
-    r.method,
-    r.route,
-    {
-      url: r.url,
-      params: r.params,
-    },
-  ])
-
-  // In the tests, there is a single POST test per entity,
-  // that creates a new object.
-  //
-  // After this POST test and before the next POST test,
-  // there is most likely a DELETE test. In order to prevent side-effects,
-  // such as cascade deleting, or having to clear relations, the
-  // DELETE test will be performed on the newly POSTed object.
-  //
-  // This ID saves that ID for future use for DELETE.
-  let id: string
-
-  test.each(tests)('%p %p', async (method, route, routeInfo) => {
-    // 1. Prepare request
-
-    // ---- unpack data
-    let url = routeInfo.url || route
-    const params = routeInfo.params
-
-    // ---- fill in path params if required
-    if (method === 'delete') {
-      url = url.replaceAll(':userId', id)
-      url = url.replaceAll(':degreeId', id)
-      url = url.replaceAll(':graphId', id)
-    } else {
-      url = url.replaceAll(':userId', u1.id)
-      url = url.replaceAll(':degreeId', d1.id)
-      url = url.replaceAll(':graphId', g1.id)
-      url = url.replaceAll(':authZeroId', u1.authZeroId)
-    }
-
-    // ---- fill in query params if required
-    if (params) {
-      if (params.hasOwnProperty('degreeIds')) {
-        // used in:
-        // - degree list
-        // - user add degree
-        params['degreeIds'].push(d2.id)
-      }
-      if (params.hasOwnProperty('graphIds')) {
-        // used in:
-        // - user add graph
-        params['graphIds'].push(g2.id)
-      }
-      if (params.hasOwnProperty('degreeId')) {
-        // used in:
-        // - user set main degree
-        params['degreeId'] = d2.id
-      }
-      if (params.hasOwnProperty('graphId')) {
-        // used in:
-        // - user set main graph
-        params['graphId'] = g2.id
-      }
-      if (method === 'post' && route === '/graph') {
-        // used in:
-        // - create graph
-        params['userId'] = u1.id
-        params['degreeId'] = d1.id
-      }
-    }
-
-    // 2. Make request
-    const res = await postman.send(method, url, params)
-
-    // 3. Transform data
-    const data = {
-      method: res.config.method,
-      url: res.config.url,
-      res: res.data,
-    }
-
-    all.push(data)
-
-    // 4. Save ID if created new entity
-    if (isEntityCreation(method, route)) {
-      id = res.data.id
-    }
-
-    expect(1).toEqual(1)
-  })
-
-  test('write to file', () => {
-    const rootDir = join(__dirname, '../../..')
-    const json = JSON.stringify(all, null, 2)
-    fs.writeFileSync(join(rootDir, 'references/api.json'), json)
-
-    expect(1).toEqual(1)
-  })
-})
+}

--- a/libs/auto-docs/test/setup.test.ts
+++ b/libs/auto-docs/test/setup.test.ts
@@ -40,16 +40,17 @@ test('server is running', async () => {
 })
 
 if (serverRunning) {
-  describe('bare minimum', () => {
+  describe('entity check', () => {
     test('runs with no errors', async () => {
       const res = await api.autoSetup(init)
+      expect(res).toHaveSameKeysAs(['u1', 'u2', 'd1', 'd2', 'g1', 'g2'])
+      // unpack data
       u1 = res.u1
       u2 = res.u2
       d1 = res.d1
       d2 = res.d2
       g1 = res.g1
       g2 = res.g2
-      expect(1).toEqual(1)
     })
 
     test('has 2 users', async () => {
@@ -76,14 +77,16 @@ if (serverRunning) {
     let degreeKeys: string[]
     let graphKeys: string[]
 
-    test('get keys', () => {
+    test('modtree entities have keys', () => {
       userKeys = Object.keys(Repo.User.metadata.propertiesMap)
       degreeKeys = Object.keys(Repo.Degree.metadata.propertiesMap)
       graphKeys = Object.keys(Repo.Graph.metadata.propertiesMap)
-      expect(1).toEqual(1)
+      expect(userKeys.length).toBeGreaterThan(0)
+      expect(degreeKeys.length).toBeGreaterThan(0)
+      expect(graphKeys.length).toBeGreaterThan(0)
     })
 
-    test('all properties exist', () => {
+    test('each entity instance has all keys', () => {
       expect(Object.keys(u1)).toIncludeSameMembers(userKeys)
       expect(Object.keys(u2)).toIncludeSameMembers(userKeys)
       expect(Object.keys(d1)).toIncludeSameMembers(degreeKeys)


### PR DESCRIPTION
### Summary of changes

Technically, #265 fixes issue #264 by excluding auto-docs from `yarn test`.

This PR prevents `references/api.json` from being overwritten if you specifically run `yarn nx test auto-docs`.

### Testing

`yarn nx test auto-docs` should not overwrite `references/api.json`, if the server is not running

