### PR TITLE
feat: module context menu

### DIFF
--- a/apps/server/src/api/user.ts
+++ b/apps/server/src/api/user.ts
@@ -102,6 +102,8 @@ export class UserApi {
         mainGraph: {
           // does not fetch degree modules
           degree: true,
+          modulesPlaced: true,
+          modulesHidden: true,
         },
       },
     })

--- a/apps/web/api/graph.ts
+++ b/apps/web/api/graph.ts
@@ -8,4 +8,13 @@ export class GraphApi extends BaseApi {
   async getById(graphId: string): Promise<IGraph> {
     return this.server.get(`/graph/${graphId}`).then((res) => res.data)
   }
+
+  /**
+   * toggle module in graph
+   */
+  async toggle(graphId: string, moduleCode: string): Promise<IGraph> {
+    return this.server
+      .patch(`/graph/${graphId}/toggle/${moduleCode}`)
+      .then((res) => res.data)
+  }
 }

--- a/apps/web/components/menu-items.ts
+++ b/apps/web/components/menu-items.ts
@@ -1,7 +1,8 @@
 import { MenuItem } from 'types'
 import store from '@/store/redux'
-import { showDebugModal, showUserProfile } from '@/store/modal'
+import { showDebugModal, showModuleModal, showUserProfile } from '@/store/modal'
 import { removeModuleNode } from '@/store/graph'
+import { api } from 'api'
 
 const dispatch = store.dispatch
 
@@ -22,7 +23,7 @@ const userDropdownMenu: MenuItem[] = [
 ]
 
 const flowNodeContextMenu: MenuItem[] = [
-  { text: 'More info' },
+  { text: 'More info', callback: (e) => api.module.openModuleModal(e.id) },
   { text: 'Suggest modules', callback: () => alert('suggest modules') },
   { text: 'Mark as done', callback: () => alert('marked as done') },
   {

--- a/apps/web/components/menu-items.ts
+++ b/apps/web/components/menu-items.ts
@@ -1,8 +1,9 @@
 import { MenuItem } from 'types'
 import store from '@/store/redux'
 import { showDebugModal, showUserProfile } from '@/store/modal'
-import { removeModuleNode } from '@/store/graph'
+import { removeModuleNode, setGraph } from '@/store/graph'
 import { api } from 'api'
+import { setUser } from '@/store/user'
 
 const dispatch = store.dispatch
 
@@ -31,7 +32,14 @@ const flowNodeContextMenu: MenuItem[] = [
     callback: async (e) => {
       // update graph
       const mainGraph = store.getState().user.mainGraph
-      api.graph.toggle(mainGraph.id, e.id)
+      const userId = store.getState().user.id
+      api.graph
+        .toggle(mainGraph.id, e.id)
+        .then(() => api.user.getById(userId))
+        .then((user) => {
+          store.dispatch(setGraph(user.mainGraph))
+          store.dispatch(setUser(user))
+        })
       // remove node from frontend
       store.dispatch(removeModuleNode(e))
     },

--- a/apps/web/components/menu-items.ts
+++ b/apps/web/components/menu-items.ts
@@ -1,6 +1,6 @@
 import { MenuItem } from 'types'
 import store from '@/store/redux'
-import { showDebugModal, showModuleModal, showUserProfile } from '@/store/modal'
+import { showDebugModal, showUserProfile } from '@/store/modal'
 import { removeModuleNode } from '@/store/graph'
 import { api } from 'api'
 
@@ -28,7 +28,13 @@ const flowNodeContextMenu: MenuItem[] = [
   { text: 'Mark as done', callback: () => alert('marked as done') },
   {
     text: 'Remove',
-    callback: (e) => store.dispatch(removeModuleNode(e)),
+    callback: async (e) => {
+      // update graph
+      const mainGraph = store.getState().user.mainGraph
+      api.graph.toggle(mainGraph.id, e.id)
+      // remove node from frontend
+      store.dispatch(removeModuleNode(e))
+    },
   },
 ]
 

--- a/apps/web/components/modals/module-info/contents.tsx
+++ b/apps/web/components/modals/module-info/contents.tsx
@@ -5,6 +5,7 @@ import { useAppDispatch, useAppSelector } from '@/store/redux'
 import { Button } from '@/ui/buttons'
 import { useUser } from '@/utils/auth0'
 import { empty } from '@modtree/utils'
+import { inModulesPlaced } from '@/utils/graph'
 
 export function ModuleDetails() {
   const module = useAppSelector((state) => state.modal.modalModule)
@@ -28,6 +29,10 @@ export function ModuleDetails() {
     )
     dispatch(hideModuleModal())
   }
+
+  // get main graph to chek if this module has been added
+  const mainGraph = useAppSelector((state) => state.user.mainGraph)
+
   return (
     <div>
       <h1 className="text-modtree-400">{module.moduleCode}</h1>
@@ -41,7 +46,7 @@ export function ModuleDetails() {
       </p>
       <hr />
       <p className="mb-6">{module.description}</p>
-      {user && (
+      {user && !inModulesPlaced(mainGraph, module.moduleCode) && (
         <div className="flex flex-row-reverse">
           <Button onClick={handleAddButton}>Add to graph</Button>
         </div>

--- a/apps/web/utils/graph/index.ts
+++ b/apps/web/utils/graph/index.ts
@@ -1,4 +1,5 @@
 import { Graph } from '@modtree/types'
+import { flatten } from '@modtree/utils'
 import { lowercaseAndDash } from '../string'
 
 /**
@@ -8,4 +9,12 @@ export function getUniqueGraphTitle(graph: Graph) {
   const degreeTitle = lowercaseAndDash(graph.degree.title)
   const graphTitle = lowercaseAndDash(graph.title)
   return degreeTitle + '/' + graphTitle
+}
+
+/**
+ * Returns true if module in modulesPlaced.
+ */
+export function inModulesPlaced(graph: Graph, moduleCode: string) {
+  const placed = graph.modulesPlaced.map(flatten.module)
+  return placed.includes(moduleCode)
 }

--- a/libs/repos/src/graph/repo.ts
+++ b/libs/repos/src/graph/repo.ts
@@ -190,15 +190,15 @@ export class GraphRepository
     }
     if (state === 'placed') {
       toggle(graph.modulesPlaced, graph.modulesHidden)
-      return this.save(graph)
-    }
-    if (state === 'hidden') {
-      toggle(graph.modulesHidden, graph.modulesPlaced)
       // remove from flowNodes and flowEdges
       graph.flowNodes = graph.flowNodes.filter((n) => n.id !== moduleCode)
       graph.flowEdges = graph.flowEdges.filter(
         (n) => n.source !== moduleCode && n.target !== moduleCode
       )
+      return this.save(graph)
+    }
+    if (state === 'hidden') {
+      toggle(graph.modulesHidden, graph.modulesPlaced)
       return this.save(graph)
     }
 

--- a/libs/repos/src/graph/repo.ts
+++ b/libs/repos/src/graph/repo.ts
@@ -194,8 +194,14 @@ export class GraphRepository
     }
     if (state === 'hidden') {
       toggle(graph.modulesHidden, graph.modulesPlaced)
+      // remove from flowNodes and flowEdges
+      graph.flowNodes = graph.flowNodes.filter((n) => n.id !== moduleCode)
+      graph.flowEdges = graph.flowEdges.filter(
+        (n) => n.source !== moduleCode && n.target !== moduleCode
+      )
       return this.save(graph)
     }
+
     return this.moduleRepo.findOneByOrFail({ moduleCode }).then((module) => {
       graph.modulesPlaced.push(module)
       return this.save(graph)


### PR DESCRIPTION
### Summary of changes

- In module info modal, "Add to graph" is hidden if the module is in `graph.modulesPlaced`
- "More info" context menu option is now functional
- "Remove" context menu option persists

### Testing

- Search for a module that is already placed. The modal should not display "Add to graph"
- Click "More info" menu item for a placed module. The modal should not display "Add to graph"
- Remove a module from the graph. You should be able to add back the module immediately. Upon refresh, the removed module stays removed.