### PR TITLE
test: mock degree initialize

### DIFF
--- a/libs/repos/src/api/base.ts
+++ b/libs/repos/src/api/base.ts
@@ -1,4 +1,4 @@
-import { DataSource } from 'typeorm'
+import { DataSource, Repository } from 'typeorm'
 import {
   IUserRepository,
   IDegreeRepository,
@@ -7,6 +7,7 @@ import {
   IModuleCondensedRepository,
   EntityName,
   IModuleFullRepository,
+  Graph,
 } from '@modtree/types'
 import {
   UserRepository,
@@ -32,12 +33,20 @@ export abstract class BaseApi {
 
   constructor(db: DataSource) {
     this.db = db
-    this.degreeRepo = new DegreeRepository(db)
-    this.userRepo = new UserRepository(db)
-    this.graphRepo = new GraphRepository(db)
-    this.moduleRepo = new ModuleRepository(db)
     this.moduleFullRepo = new ModuleFullRepository(db)
     this.moduleCondensedRepo = new ModuleCondensedRepository(db)
+    this.moduleRepo = new ModuleRepository(db)
+    this.degreeRepo = new DegreeRepository(db, { module: this.moduleRepo })
+    this.userRepo = new UserRepository(db, {
+      module: this.moduleRepo,
+      degree: this.degreeRepo,
+      graph: new Repository(Graph, db.manager),
+    })
+    this.graphRepo = new GraphRepository(db, {
+      module: this.moduleRepo,
+      degree: this.degreeRepo,
+      user: this.userRepo,
+    })
     this.relations = {
       user: getRelationNames(this.userRepo),
       degree: getRelationNames(this.degreeRepo),

--- a/libs/repos/src/degree/repo.ts
+++ b/libs/repos/src/degree/repo.ts
@@ -3,30 +3,27 @@ import {
   Degree,
   IDegreeRepository,
   IModuleRepository,
-  FindByKey,
-  IDegree,
   InitDegreeProps,
 } from '@modtree/types'
-import { getRelationNames, useDeleteAll, useFindOneByKey } from '../utils'
-import { ModuleRepository } from '../module'
+import { useDeleteAll } from '../utils'
+import { getRelationsFromMetadata } from '../utils/get-relation-names'
 
 export class DegreeRepository
   extends Repository<Degree>
   implements IDegreeRepository
 {
-  private db: DataSource
-  private allRelations = getRelationNames(this)
+  private allRelations: Record<string, boolean>
   private moduleRepo: IModuleRepository
 
-  constructor(db: DataSource) {
+  constructor(db: DataSource, repos: { module: IModuleRepository }) {
     super(Degree, db.manager)
-    this.db = db
-    this.moduleRepo = new ModuleRepository(this.db)
+    this.allRelations = getRelationsFromMetadata(db.getMetadata(Degree))
+    this.moduleRepo = repos.module
   }
 
   deleteAll = useDeleteAll(this)
-  override findOneById: FindByKey<IDegree> = useFindOneByKey(this, 'id')
-  findOneByTitle = useFindOneByKey(this, 'title')
+  override findOneById = async (id: string) => this.findOneByOrFail({ id })
+  findOneByTitle = async (title: string) => this.findOneByOrFail({ title })
 
   /**
    * Adds a Degree to DB

--- a/libs/repos/src/degree/test/initialize.mock.json
+++ b/libs/repos/src/degree/test/initialize.mock.json
@@ -1,0 +1,71 @@
+{
+  "moduleRepo": {
+    "findByCodes": [
+      {
+        "id": "1",
+        "moduleCode": "CS1101S",
+        "title": "Programming Methodology",
+        "prerequisite": "",
+        "corequisite": "",
+        "preclusion": "CS1010 or its equivalents",
+        "fulfillRequirements": [
+          "FIN4124",
+          "FIN4719",
+          "MA3269",
+          "CS2109S",
+          "QF2103"
+        ],
+        "prereqTree": ""
+      },
+      {
+        "id": "2",
+        "moduleCode": "CS1231S",
+        "title": "Discrete Structures",
+        "prerequisite": "A-level Mathematics or H2 Mathematics or MA1301 or MA1301FC or MA1301X",
+        "corequisite": "",
+        "preclusion": "MA1100 and CS1231 or its equivalent",
+        "fulfillRequirements": [
+          "CS5469",
+          "CS4269",
+          "MA2202",
+          "MA2202S",
+          "MA2214",
+          "MA2219",
+          "MA3205",
+          "MA3219",
+          "CS2109S"
+        ],
+        "prereqTree": {
+          "or": ["MA1301", "MA1301FC", "MA1301X"]
+        }
+      },
+      {
+        "id": "3",
+        "moduleCode": "CS2030S",
+        "title": "Programming Methodology II",
+        "prerequisite": "CS1010 or its equivalent",
+        "corequisite": "",
+        "preclusion": "CS2030",
+        "fulfillRequirements": [],
+        "prereqTree": "CS1010"
+      },
+      {
+        "id": "4",
+        "moduleCode": "CS2040S",
+        "title": "Data Structures and Algorithms",
+        "prerequisite": "(MA1100 or (CS1231 or its equivalent)) and (CS1010 or its equivalent)",
+        "corequisite": "",
+        "preclusion": "CS1020, CS1020E, CS2020, CS2010, CS2040, CS2040C",
+        "fulfillRequirements": ["CS2113", "CS2113T", "CS5469", "CS4269"],
+        "prereqTree": {
+          "and": [
+            {
+              "or": ["MA1100", "CS1231"]
+            },
+            "CS1010"
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/libs/repos/src/graph/repo.ts
+++ b/libs/repos/src/graph/repo.ts
@@ -20,9 +20,6 @@ import {
   nodify,
 } from '@modtree/utils'
 import { getRelationNames, useDeleteAll, useFindOneByKey } from '../utils'
-import { ModuleRepository } from '../module'
-import { UserRepository } from '../user'
-import { DegreeRepository } from '../degree'
 import { getModules } from './get-modules'
 
 type ModuleState = 'placed' | 'hidden' | 'new'
@@ -31,18 +28,23 @@ export class GraphRepository
   extends Repository<Graph>
   implements IGraphRepository
 {
-  private db: DataSource
   private allRelations = getRelationNames(this)
   private moduleRepo: IModuleRepository
   private degreeRepo: IDegreeRepository
   private userRepo: IUserRepository
 
-  constructor(db: DataSource) {
+  constructor(
+    db: DataSource,
+    repos: {
+      module: IModuleRepository
+      degree: IDegreeRepository
+      user: IUserRepository
+    }
+  ) {
     super(Graph, db.manager)
-    this.db = db
-    this.moduleRepo = new ModuleRepository(this.db)
-    this.degreeRepo = new DegreeRepository(this.db)
-    this.userRepo = new UserRepository(this.db)
+    this.moduleRepo = repos.module
+    this.degreeRepo = repos.degree
+    this.userRepo = repos.user
   }
 
   deleteAll = useDeleteAll(this)

--- a/libs/repos/src/module/repo.ts
+++ b/libs/repos/src/module/repo.ts
@@ -1,13 +1,8 @@
 import { DataSource, In, Repository } from 'typeorm'
-import {
-  Module,
-  IModuleRepository,
-  FindByKey,
-  InitModuleProps,
-} from '@modtree/types'
+import { Module, IModuleRepository, InitModuleProps } from '@modtree/types'
 import { flatten, unique } from '@modtree/utils'
 import { hasTakenModule, checkTree } from './utils'
-import { useDeleteAll, useFindOneByKey } from '../utils'
+import { useDeleteAll } from '../utils'
 
 type Data = {
   moduleCode: string
@@ -25,7 +20,7 @@ export class ModuleRepository
   }
 
   deleteAll = useDeleteAll(this)
-  override findOneById: FindByKey<Module> = useFindOneByKey(this, 'id')
+  override findOneById = async (id: string) => this.findOneByOrFail({ id })
 
   /**
    * initialize a Module

--- a/libs/repos/src/user/repo.ts
+++ b/libs/repos/src/user/repo.ts
@@ -10,28 +10,33 @@ import {
   IUser,
   IUserRepository,
   ModuleStatus,
+  IDegreeRepository,
 } from '@modtree/types'
 import { flatten } from '@modtree/utils'
 import { getRelationNames, useDeleteAll, useFindOneByKey } from '../utils'
-import { ModuleRepository } from '../module'
 
 export class UserRepository
   extends Repository<User>
   implements IUserRepository
 {
-  private db: DataSource
   private moduleRepo: IModuleRepository
   private degreeRepo: Repository<Degree>
   private graphRepo: Repository<Graph>
 
   private graphRelations
 
-  constructor(db: DataSource) {
+  constructor(
+    db: DataSource,
+    repos: {
+      module: IModuleRepository
+      degree: IDegreeRepository
+      graph: Repository<Graph>
+    }
+  ) {
     super(User, db.manager)
-    this.db = db
-    this.moduleRepo = new ModuleRepository(this.db)
-    this.degreeRepo = new Repository(Degree, this.db.manager)
-    this.graphRepo = new Repository(Graph, this.db.manager)
+    this.moduleRepo = repos.module
+    this.degreeRepo = repos.degree
+    this.graphRepo = repos.graph
     this.graphRelations = getRelationNames(this.graphRepo)
   }
 

--- a/libs/repos/src/utils/get-relation-names.ts
+++ b/libs/repos/src/utils/get-relation-names.ts
@@ -1,4 +1,4 @@
-import { Repository } from 'typeorm'
+import { EntityMetadata, Repository } from 'typeorm'
 
 /**
  * Returns the relation names of an entity,
@@ -12,6 +12,25 @@ export function getRelationNames<T>(
 ): Record<string, boolean> {
   const meta = repository.metadata
   const relationNames = meta.relations.map((r) => r.propertyName)
+  // make into Record for loadRelations
+  const res: Record<string, boolean> = {}
+  relationNames.forEach((r) => {
+    res[r] = true
+  })
+  return res
+}
+
+/**
+ * Returns the relation names of an entity,
+ * in the format for loadRelations.
+ *
+ * @param {EntityMetadata} metadata
+ * @returns {Record<string, boolean>}
+ */
+export function getRelationsFromMetadata(
+  metadata: EntityMetadata
+): Record<string, boolean> {
+  const relationNames = metadata.relations.map((r) => r.propertyName)
   // make into Record for loadRelations
   const res: Record<string, boolean> = {}
   relationNames.forEach((r) => {

--- a/libs/test-env/src/mocks.ts
+++ b/libs/test-env/src/mocks.ts
@@ -1,22 +1,21 @@
-import { Module } from '@modtree/types'
-import { DataSource, EntityTarget } from 'typeorm'
+import { DataSource } from 'typeorm'
 
-function getMockDb(): any {
-  const db: any = new DataSource({
+function getMockDb(): DataSource {
+  const db = new DataSource({
     database: 'mock',
     type: 'postgres',
-  })
-  db.getMetadata = <T>(e: EntityTarget<T>) => {
-    if (e === Module) {
-      return {
-        relations: [],
-      }
-    }
-    return {
-      relations: [],
-    }
+  }) as any
+  db.manager = {
+    whereInIds: () => {},
+    connection: { getMetadata: () => {} },
   }
+  db.getMetadata = () => ({
+    relations: [],
+  })
+  db.createQueryBuilder = () => ({
+    whereInIds: () => {},
+  })
   return db
 }
 
-export const db = getMockDb()
+export const db = getMockDb() as any


### PR DESCRIPTION
### Summary of changes

- degree initialize test now fully doesn't touch database
- this is significant because
  1. it's the first mock with a relation
  2. it's a mock that preserves types

### Testing

- `yarn jest --testPathPattern=libs/repos/src/degree/test/initialize` from workspace root
