### PR TITLE
feat: persist adding node to graph

### DIFF
--- a/apps/server/src/routes.ts
+++ b/apps/server/src/routes.ts
@@ -171,7 +171,7 @@ export const routes: Route[] = [
     method: 'post',
     route: '/graph',
     fn: GraphApi.create,
-    validators: [],
+    validators: [body('title').isString().notEmpty()],
   },
   {
     method: 'patch',

--- a/apps/web/api/graph.ts
+++ b/apps/web/api/graph.ts
@@ -1,4 +1,4 @@
-import { IGraph } from '@modtree/types'
+import { GraphFlowEdge, GraphFlowNode, IGraph } from '@modtree/types'
 import { BaseApi } from './base-api'
 
 export class GraphApi extends BaseApi {
@@ -15,6 +15,22 @@ export class GraphApi extends BaseApi {
   async toggle(graphId: string, moduleCode: string): Promise<IGraph> {
     return this.server
       .patch(`/graph/${graphId}/toggle/${moduleCode}`)
+      .then((res) => res.data)
+  }
+
+  /**
+   * update frontend props
+   */
+  async updateFrontendProps(
+    graphId: string,
+    flowNodes: GraphFlowNode[],
+    flowEdges: GraphFlowEdge[]
+  ): Promise<IGraph> {
+    return this.server
+      .patch(`/graph/${graphId}/flow`, {
+        flowNodes,
+        flowEdges,
+      })
       .then((res) => res.data)
   }
 }

--- a/apps/web/components/menu-items.ts
+++ b/apps/web/components/menu-items.ts
@@ -3,7 +3,7 @@ import store from '@/store/redux'
 import { showDebugModal, showUserProfile } from '@/store/modal'
 import { removeModuleNode, setGraph } from '@/store/graph'
 import { api } from 'api'
-import { setUser } from '@/store/user'
+import { updateUser } from '@/utils/rehydrate'
 
 const dispatch = store.dispatch
 
@@ -32,13 +32,11 @@ const flowNodeContextMenu: MenuItem[] = [
     callback: async (e) => {
       // update graph
       const mainGraph = store.getState().user.mainGraph
-      const userId = store.getState().user.id
       api.graph
         .toggle(mainGraph.id, e.id)
-        .then(() => api.user.getById(userId))
+        .then(() => updateUser())
         .then((user) => {
           store.dispatch(setGraph(user.mainGraph))
-          store.dispatch(setUser(user))
         })
       // remove node from frontend
       store.dispatch(removeModuleNode(e))

--- a/apps/web/components/modals/module-info/contents.tsx
+++ b/apps/web/components/modals/module-info/contents.tsx
@@ -1,5 +1,5 @@
 import { Dot } from '@/ui/inline'
-import { addModuleNode, setGraph, setFlow } from '@/store/graph'
+import { setGraph, setFlow } from '@/store/graph'
 import { hideModuleModal } from '@/store/modal'
 import { useAppDispatch, useAppSelector } from '@/store/redux'
 import { Button } from '@/ui/buttons'

--- a/apps/web/components/modals/module-info/contents.tsx
+++ b/apps/web/components/modals/module-info/contents.tsx
@@ -1,38 +1,64 @@
 import { Dot } from '@/ui/inline'
-import { addModuleNode } from '@/store/graph'
+import { addModuleNode, setGraph, setFlow } from '@/store/graph'
 import { hideModuleModal } from '@/store/modal'
 import { useAppDispatch, useAppSelector } from '@/store/redux'
 import { Button } from '@/ui/buttons'
 import { useUser } from '@/utils/auth0'
 import { empty } from '@modtree/utils'
 import { inModulesPlaced } from '@/utils/graph'
+import { api } from 'api'
+import { updateUser } from '@/utils/rehydrate'
+import { GraphFlowNode } from '@modtree/types'
+import { redrawGraph } from '@/utils/flow'
 
 export function ModuleDetails() {
   const module = useAppSelector((state) => state.modal.modalModule)
   const { user } = useUser()
   const dispatch = useAppDispatch()
-  function handleAddButton() {
-    dispatch(
-      addModuleNode({
-        id: module.moduleCode,
-        position: {
-          x: 0,
-          y: 0,
-        },
-        type: 'moduleNode',
-        data: {
-          ...empty.Module,
-          moduleCode: module.moduleCode,
-          title: module.title,
-        },
-      })
-    )
-    dispatch(hideModuleModal())
-  }
 
-  // get main graph to chek if this module has been added
+  // to check if this module has been added
+  // and to toggle node
   const mainGraph = useAppSelector((state) => state.user.mainGraph)
 
+  function handleAddButton() {
+    // 1. hide module modal
+    dispatch(hideModuleModal())
+
+    // 2. calculate new nodes and edges
+    const node: GraphFlowNode = {
+      id: module.moduleCode,
+      position: {
+        x: 0,
+        y: 0,
+      },
+      type: 'moduleNode',
+      data: {
+        ...empty.Module,
+        moduleCode: module.moduleCode,
+        title: module.title,
+      },
+    }
+    const { nodes, edges } = redrawGraph({
+      nodes: [...mainGraph.flowNodes, node],
+      edges: mainGraph.flowEdges,
+    })
+    dispatch(
+      setFlow({
+        flowNodes: nodes,
+        flowEdges: edges,
+      })
+    )
+
+    // 3. toggle module in graph
+    api.graph
+      .toggle(mainGraph.id, module.moduleCode)
+      .then(() =>
+        // 4. update frontend props
+        api.graph.updateFrontendProps(mainGraph.id, nodes, edges)
+      )
+      .then(() => updateUser())
+      .then((user) => setGraph(user.mainGraph))
+  }
   return (
     <div>
       <h1 className="text-modtree-400">{module.moduleCode}</h1>

--- a/apps/web/components/user-profile/degrees/add-new.tsx
+++ b/apps/web/components/user-profile/degrees/add-new.tsx
@@ -11,8 +11,8 @@ import { useAppDispatch, useAppSelector } from '@/store/redux'
 import { clearBuildList, removeFromBuildList } from '@/store/search'
 import { api } from 'api'
 import { useUser } from '@/utils/auth0'
-import { setUser } from '@/store/user'
 import { flatten } from '@modtree/utils'
+import { updateUser } from '@/utils/rehydrate'
 
 function SelectedModules(props: { modules: IModule[] }) {
   const dispatch = useAppDispatch()
@@ -57,8 +57,7 @@ export function AddNew(props: { setPage: SetState<Pages['Degrees']> }) {
     api.degree
       .create(degreeProps)
       .then((degree) => api.user.insertDegree(user.modtreeId, degree.id))
-      .then(() => api.user.getById(user.modtreeId))
-      .then((user) => dispatch(setUser(user)))
+      .then(() => updateUser())
       .then(() => props.setPage('main'))
   }
 

--- a/apps/web/components/user-profile/degrees/edit.tsx
+++ b/apps/web/components/user-profile/degrees/edit.tsx
@@ -9,12 +9,10 @@ import { useAppDispatch, useAppSelector } from '@/store/redux'
 import { SelectedModules } from '../modules/selected-modules'
 import { setBuildList } from '@/store/search'
 import { api } from 'api'
-import { useUser } from '@/utils/auth0'
-import { setUser } from '@/store/user'
 import { flatten } from '@modtree/utils'
+import { updateUser } from '@/utils/rehydrate'
 
 export function Edit(props: { setPage: SetState<Pages['Degrees']> }) {
-  const { user } = useUser()
   const { buildList, buildTitle, buildId } = useAppSelector(
     (state) => state.search
   )
@@ -39,8 +37,7 @@ export function Edit(props: { setPage: SetState<Pages['Degrees']> }) {
     }
     api.degree
       .modify(buildId, degreeProps)
-      .then(() => api.user.getById(user.modtreeId))
-      .then((user) => dispatch(setUser(user)))
+      .then(() => updateUser())
       .then(() => props.setPage('main'))
   }
 

--- a/apps/web/components/user-profile/degrees/main.tsx
+++ b/apps/web/components/user-profile/degrees/main.tsx
@@ -8,7 +8,7 @@ import { useAppDispatch, useAppSelector } from '@/store/redux'
 import { clearBuildList, setBuildId, setBuildTitle } from '@/store/search'
 import { useUser } from '@/utils/auth0'
 import { api } from 'api'
-import { setUser } from '@/store/user'
+import { updateUser } from '@/utils/rehydrate'
 
 export function Main(props: {
   setPage: Dispatch<SetStateAction<Pages['Degrees']>>
@@ -19,10 +19,7 @@ export function Main(props: {
   const { user } = useUser()
 
   async function removeDegree(degreeId: string) {
-    api.user
-      .removeDegree(user.modtreeId, degreeId)
-      .then(() => api.user.getById(user.modtreeId))
-      .then((user) => dispatch(setUser(user)))
+    api.user.removeDegree(user.modtreeId, degreeId).then(() => updateUser())
   }
 
   return (

--- a/apps/web/store/graph.ts
+++ b/apps/web/store/graph.ts
@@ -54,6 +54,14 @@ export const graph = createSlice({
       graph.flowEdges = edges
     },
 
+    /**
+     * Update flow nodes and edges.
+     *
+     * redrawGraph is called in the React component, so that the new nodes and
+     * edges can be sent to the API endpoint to update the graph.
+     *
+     * No need to check for duplicates as the frontend prevents this
+     */
     setFlow: (graph, action: PayloadAction<GraphFrontendProps>) => {
       if (!action.payload) return
       const data = action.payload

--- a/apps/web/store/graph.ts
+++ b/apps/web/store/graph.ts
@@ -1,5 +1,5 @@
 import { redrawGraph } from '@/utils/flow'
-import { IGraph, GraphFlowNode } from '@modtree/types'
+import { IGraph, GraphFlowNode, GraphFrontendProps } from '@modtree/types'
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { baseInitialState } from './initial-state'
 
@@ -54,6 +54,13 @@ export const graph = createSlice({
       graph.flowEdges = edges
     },
 
+    setFlow: (graph, action: PayloadAction<GraphFrontendProps>) => {
+      if (!action.payload) return
+      const data = action.payload
+      graph.flowNodes = data.flowNodes
+      graph.flowEdges = data.flowEdges
+    },
+
     /**
      * remove a module node from the graph
      */
@@ -92,6 +99,7 @@ export const graph = createSlice({
 export const {
   setGraphSelectedCodes,
   addModuleNode,
+  setFlow,
   updateModuleNode,
   removeModuleNode,
   setGraph,

--- a/apps/web/ui/search/graph/pick-one.tsx
+++ b/apps/web/ui/search/graph/pick-one.tsx
@@ -7,19 +7,14 @@ import { setGraph as setMainGraph } from '@/store/graph'
 import { useEffect } from 'react'
 import { api } from 'api'
 import { useUser } from '@/utils/auth0'
-import { setUser } from '@/store/user'
-import { useAppDispatch } from '@/store/redux'
+import { updateUser } from '@/utils/rehydrate'
 
 export function PickOne(props: { graphs: IGraph[]; select: UseState<IGraph> }) {
   const { user } = useUser()
   const [graph, setGraph] = props.select
-  const dispatch = useAppDispatch()
 
   useEffect(() => {
-    api.user
-      .setMainGraph(user.modtreeId, graph.id)
-      .then(() => api.user.getById(user.modtreeId))
-      .then((user) => dispatch(setUser(user)))
+    api.user.setMainGraph(user.modtreeId, graph.id).then(() => updateUser())
     setMainGraph(graph)
   }, [graph])
 

--- a/apps/web/utils/rehydrate.ts
+++ b/apps/web/utils/rehydrate.ts
@@ -42,3 +42,14 @@ export function rehydrate(user: ModtreeUserProfile) {
     }
   })
 }
+
+/**
+ * Fetch and update user with latest data.
+ */
+export async function updateUser() {
+  const userId = store.getState().user.id
+  return api.user.getById(userId).then((user) => {
+    dispatch(setUser(user))
+    return user
+  })
+}

--- a/apps/web/utils/rehydrate.ts
+++ b/apps/web/utils/rehydrate.ts
@@ -24,6 +24,9 @@ async function getUser(user: ModtreeUserProfile): Promise<IUser> {
   }
 }
 
+/**
+ * Loads main degree/graph into store, if not yet loaded.
+ */
 export function rehydrate(user: ModtreeUserProfile) {
   const userPromise = getUser(user)
   userPromise.then((user) => {

--- a/libs/types/src/entities/Graph.ts
+++ b/libs/types/src/entities/Graph.ts
@@ -21,7 +21,7 @@ export class Graph implements IGraph {
   @PrimaryGeneratedColumn('uuid')
   id: string
 
-  @Column('character varying')
+  @Column('character varying', { default: 'graph' })
   title: string
 
   @ManyToOne('User', 'graph', { onDelete: 'CASCADE' })


### PR DESCRIPTION
### Summary of changes

- Adding a node to graph now persists

### Testing

- Try adding a node to the graph, and refresh the page.
- You should still see the node, and the nodes and edges are at the same positions.
- Note that the initial load time is **rather slow** due to a slow `/user/:userId/get-full`. You can take 30 seconds or more to load the user data, as mentioned in #293.
