### PR TITLE
refactor: cleanup

### DIFF
--- a/apps/server/src/api/degree.ts
+++ b/apps/server/src/api/degree.ts
@@ -75,5 +75,6 @@ export class DegreeApi {
     return api.degreeRepo
       .findOneById(id)
       .then((degree) => api.degreeRepo.modify(degree, { title, moduleCodes }))
+      .then(flatten.degree)
   }
 }

--- a/apps/server/src/api/graph.ts
+++ b/apps/server/src/api/graph.ts
@@ -21,7 +21,7 @@ export class GraphApi {
    */
   static create = (api: Api) => async (req: Request) => {
     const props = { ...emptyInit.Graph, ...req.body }
-    return api.graphRepo.initialize(props).then(flatten.graphFull)
+    return api.graphRepo.initialize(props).then(flatten.graph)
   }
 
   /**
@@ -30,7 +30,7 @@ export class GraphApi {
    * @param {Api} api
    */
   static get = (api: Api) => async (req: CustomReqQuery<ListRequest>) => {
-    return api.graphRepo.findOneById(req.params.graphId).then(flatten.graphFull)
+    return api.graphRepo.findOneById(req.params.graphId).then(flatten.graph)
   }
 
   /**
@@ -39,7 +39,7 @@ export class GraphApi {
    * @param {Api} api
    */
   static getFull = (api: Api) => async (req: CustomReqQuery<ListRequest>) => {
-    return api.graphRepo.findOneById(req.params.graphId).then(flatten.graphFull)
+    return api.graphRepo.findOneById(req.params.graphId).then(flatten.graph)
   }
 
   /**
@@ -79,7 +79,7 @@ export class GraphApi {
     return api.graphRepo
       .findOneById(graphId)
       .then((graph) => api.graphRepo.toggleModule(graph, moduleCode))
-      .then(flatten.graphFull)
+      .then(flatten.graph)
   }
 
   /**
@@ -98,7 +98,7 @@ export class GraphApi {
           flowNodes,
         })
       )
-      .then(flatten.graphFull)
+      .then(flatten.graph)
   }
 
   /**
@@ -112,7 +112,7 @@ export class GraphApi {
     return api.graphRepo
       .findOneById(graphId)
       .then((graph) => api.graphRepo.updateFlowNode(graph, flowNode))
-      .then(flatten.graphFull)
+      .then(flatten.graph)
   }
 
   /**

--- a/apps/server/src/api/graph.ts
+++ b/apps/server/src/api/graph.ts
@@ -21,7 +21,7 @@ export class GraphApi {
    */
   static create = (api: Api) => async (req: Request) => {
     const props = { ...emptyInit.Graph, ...req.body }
-    return api.graphRepo.initialize(props).then(flatten.graph)
+    return api.graphRepo.initialize(props).then(flatten.graphFull)
   }
 
   /**

--- a/apps/server/src/api/graph.ts
+++ b/apps/server/src/api/graph.ts
@@ -79,7 +79,7 @@ export class GraphApi {
     return api.graphRepo
       .findOneById(graphId)
       .then((graph) => api.graphRepo.toggleModule(graph, moduleCode))
-      .then(flatten.graph)
+      .then(flatten.graphFull)
   }
 
   /**

--- a/apps/server/src/api/graph.ts
+++ b/apps/server/src/api/graph.ts
@@ -30,7 +30,7 @@ export class GraphApi {
    * @param {Api} api
    */
   static get = (api: Api) => async (req: CustomReqQuery<ListRequest>) => {
-    return api.graphRepo.findOneById(req.params.graphId).then(flatten.graph)
+    return api.graphRepo.findOneById(req.params.graphId).then(flatten.graphFull)
   }
 
   /**
@@ -112,7 +112,7 @@ export class GraphApi {
     return api.graphRepo
       .findOneById(graphId)
       .then((graph) => api.graphRepo.updateFlowNode(graph, flowNode))
-      .then(flatten.graph)
+      .then(flatten.graphFull)
   }
 
   /**

--- a/apps/server/src/api/graph.ts
+++ b/apps/server/src/api/graph.ts
@@ -98,7 +98,7 @@ export class GraphApi {
           flowNodes,
         })
       )
-      .then(flatten.graph)
+      .then(flatten.graphFull)
   }
 
   /**

--- a/apps/server/src/api/graph.ts
+++ b/apps/server/src/api/graph.ts
@@ -126,6 +126,6 @@ export class GraphApi {
     return api.graphRepo
       .findOneById(graphId)
       .then((graph) => api.graphRepo.suggestModules(graph, selectedCodes))
-      .then((modules) => modules.map((m) => flatten.module(m)))
+      .then((modules) => modules.map(flatten.module))
   }
 }

--- a/apps/server/src/api/user.ts
+++ b/apps/server/src/api/user.ts
@@ -146,6 +146,7 @@ export class UserApi {
     return api.userRepo
       .findOneById(id)
       .then((user) => api.userRepo.setModuleStatus(user, moduleCodes, status))
+      .then(flatten.user)
   }
 
   /**

--- a/apps/server/src/api/user.ts
+++ b/apps/server/src/api/user.ts
@@ -60,7 +60,7 @@ export class UserApi {
         where: { id, authZeroId, email },
         relations: api.userRepo.relations,
       })
-      .then((users) => users.map((u) => flatten.user(u)))
+      .then((users) => users.map(flatten.user))
   }
 
   /**

--- a/apps/web/api/degree.ts
+++ b/apps/web/api/degree.ts
@@ -1,11 +1,11 @@
-import { IDegree, InitDegreeProps } from '@modtree/types'
+import { InitDegreeProps, ModtreeApiResponse } from '@modtree/types'
 import { BaseApi } from './base-api'
 
 export class DegreeApi extends BaseApi {
   /**
    * get a degree by its id directly from database
    */
-  async getById(degreeId: string): Promise<IDegree> {
+  async getById(degreeId: string): Promise<ModtreeApiResponse.DegreeFull> {
     return this.server
       .get(`/degree/${degreeId}/get-full`)
       .then((res) => res.data)
@@ -13,7 +13,10 @@ export class DegreeApi extends BaseApi {
   /**
    * sets modules
    */
-  async modify(degreeId: string, props: InitDegreeProps): Promise<IDegree> {
+  async modify(
+    degreeId: string,
+    props: InitDegreeProps
+  ): Promise<ModtreeApiResponse.DegreeFull> {
     return this.server
       .patch(`/degree/${degreeId}`, props)
       .then((res) => res.data)
@@ -21,7 +24,7 @@ export class DegreeApi extends BaseApi {
   /**
    * create
    */
-  async create(props: InitDegreeProps): Promise<IDegree> {
+  async create(props: InitDegreeProps): Promise<ModtreeApiResponse.Degree> {
     return this.server.post(`/degree`, props).then((res) => res.data)
   }
 }

--- a/apps/web/api/degree.ts
+++ b/apps/web/api/degree.ts
@@ -5,10 +5,8 @@ export class DegreeApi extends BaseApi {
   /**
    * get a degree by its id directly from database
    */
-  async getById(degreeId: string): Promise<ModtreeApiResponse.DegreeFull> {
-    return this.server
-      .get(`/degree/${degreeId}/get-full`)
-      .then((res) => res.data)
+  async getById(degreeId: string): Promise<ModtreeApiResponse.Degree> {
+    return this.server.get(`/degree/${degreeId}`).then((res) => res.data)
   }
   /**
    * sets modules

--- a/apps/web/api/degree.ts
+++ b/apps/web/api/degree.ts
@@ -14,7 +14,7 @@ export class DegreeApi extends BaseApi {
   async modify(
     degreeId: string,
     props: InitDegreeProps
-  ): Promise<ModtreeApiResponse.DegreeFull> {
+  ): Promise<ModtreeApiResponse.Degree> {
     return this.server
       .patch(`/degree/${degreeId}`, props)
       .then((res) => res.data)

--- a/apps/web/api/graph.ts
+++ b/apps/web/api/graph.ts
@@ -10,7 +10,7 @@ export class GraphApi extends BaseApi {
   /**
    * get a graph by its id directly from database
    */
-  async getById(graphId: string): Promise<ModtreeApiResponse.GraphFull> {
+  async getById(graphId: string): Promise<ModtreeApiResponse.Graph> {
     return this.server.get(`/graph/${graphId}/get-full`).then((res) => res.data)
   }
 
@@ -20,7 +20,7 @@ export class GraphApi extends BaseApi {
   async toggle(
     graphId: string,
     moduleCode: string
-  ): Promise<ModtreeApiResponse.GraphFull> {
+  ): Promise<ModtreeApiResponse.Graph> {
     return this.server
       .patch(`/graph/${graphId}/toggle/${moduleCode}`)
       .then((res) => res.data)
@@ -33,7 +33,7 @@ export class GraphApi extends BaseApi {
     graphId: string,
     flowNodes: GraphFlowNode[],
     flowEdges: GraphFlowEdge[]
-  ): Promise<ModtreeApiResponse.GraphFull> {
+  ): Promise<ModtreeApiResponse.Graph> {
     return this.server
       .patch(`/graph/${graphId}/flow`, {
         flowNodes,
@@ -45,7 +45,7 @@ export class GraphApi extends BaseApi {
   /**
    * create
    */
-  async create(props: InitGraphProps): Promise<ModtreeApiResponse.GraphFull> {
+  async create(props: InitGraphProps): Promise<ModtreeApiResponse.Graph> {
     return this.server.post(`/graph`, props).then((res) => res.data)
   }
 }

--- a/apps/web/api/graph.ts
+++ b/apps/web/api/graph.ts
@@ -20,7 +20,7 @@ export class GraphApi extends BaseApi {
   async toggle(
     graphId: string,
     moduleCode: string
-  ): Promise<ModtreeApiResponse.GraphFull> {
+  ): Promise<ModtreeApiResponse.Graph> {
     return this.server
       .patch(`/graph/${graphId}/toggle/${moduleCode}`)
       .then((res) => res.data)
@@ -33,7 +33,7 @@ export class GraphApi extends BaseApi {
     graphId: string,
     flowNodes: GraphFlowNode[],
     flowEdges: GraphFlowEdge[]
-  ): Promise<ModtreeApiResponse.GraphFull> {
+  ): Promise<ModtreeApiResponse.Graph> {
     return this.server
       .patch(`/graph/${graphId}/flow`, {
         flowNodes,
@@ -45,7 +45,7 @@ export class GraphApi extends BaseApi {
   /**
    * create
    */
-  async create(props: InitGraphProps): Promise<ModtreeApiResponse.GraphFull> {
+  async create(props: InitGraphProps): Promise<ModtreeApiResponse.Graph> {
     return this.server.post(`/graph`, props).then((res) => res.data)
   }
 }

--- a/apps/web/api/graph.ts
+++ b/apps/web/api/graph.ts
@@ -20,7 +20,7 @@ export class GraphApi extends BaseApi {
   async toggle(
     graphId: string,
     moduleCode: string
-  ): Promise<ModtreeApiResponse.Graph> {
+  ): Promise<ModtreeApiResponse.GraphFull> {
     return this.server
       .patch(`/graph/${graphId}/toggle/${moduleCode}`)
       .then((res) => res.data)

--- a/apps/web/api/graph.ts
+++ b/apps/web/api/graph.ts
@@ -45,7 +45,7 @@ export class GraphApi extends BaseApi {
   /**
    * create
    */
-  async create(props: InitGraphProps): Promise<ModtreeApiResponse.Graph> {
+  async create(props: InitGraphProps): Promise<ModtreeApiResponse.GraphFull> {
     return this.server.post(`/graph`, props).then((res) => res.data)
   }
 }

--- a/apps/web/api/graph.ts
+++ b/apps/web/api/graph.ts
@@ -33,7 +33,7 @@ export class GraphApi extends BaseApi {
     graphId: string,
     flowNodes: GraphFlowNode[],
     flowEdges: GraphFlowEdge[]
-  ): Promise<ModtreeApiResponse.Graph> {
+  ): Promise<ModtreeApiResponse.GraphFull> {
     return this.server
       .patch(`/graph/${graphId}/flow`, {
         flowNodes,

--- a/apps/web/api/user.ts
+++ b/apps/web/api/user.ts
@@ -43,7 +43,7 @@ export class UserApi extends BaseApi {
     userId: string,
     moduleCodes: string[],
     status: ModuleStatus
-  ) {
+  ): Promise<ModtreeApiResponse.User> {
     return this.server.patch(`/user/${userId}/module`, {
       status,
       moduleCodes,
@@ -53,7 +53,10 @@ export class UserApi extends BaseApi {
   /**
    * insert degree
    */
-  async insertDegree(userId: string, degreeId: string): Promise<IUser> {
+  async insertDegree(
+    userId: string,
+    degreeId: string
+  ): Promise<ModtreeApiResponse.User> {
     return this.server.patch(`/user/${userId}/degree`, {
       degreeIds: [degreeId],
     })
@@ -62,14 +65,20 @@ export class UserApi extends BaseApi {
   /**
    * remove degree
    */
-  async removeDegree(userId: string, degreeId: string): Promise<IUser> {
+  async removeDegree(
+    userId: string,
+    degreeId: string
+  ): Promise<ModtreeApiResponse.User> {
     return this.server.delete(`/user/${userId}/degree/${degreeId}`)
   }
 
   /**
    * set main graph
    */
-  async setMainGraph(userId: string, graphId: string): Promise<IUser> {
+  async setMainGraph(
+    userId: string,
+    graphId: string
+  ): Promise<ModtreeApiResponse.User> {
     return this.server.patch(`/user/${userId}/main-graph`, {
       graphId,
     })
@@ -78,7 +87,10 @@ export class UserApi extends BaseApi {
   /**
    * insert graph
    */
-  async insertGraph(userId: string, graphId: string): Promise<IUser> {
+  async insertGraph(
+    userId: string,
+    graphId: string
+  ): Promise<ModtreeApiResponse.User> {
     return this.server.patch(`/user/${userId}/graph`, {
       graphIds: [graphId],
     })

--- a/apps/web/components/user-profile/degrees/edit.tsx
+++ b/apps/web/components/user-profile/degrees/edit.tsx
@@ -25,6 +25,7 @@ export function Edit(props: { setPage: SetState<Pages['Degrees']> }) {
     api.degree
       .getById(buildId)
       .then((degree) => degree.modules)
+      .then((moduleCodes) => api.module.getByCodes(moduleCodes))
       .then((modules) => {
         dispatch(setBuildList(modules))
       })

--- a/apps/web/components/user-profile/graphs/main.tsx
+++ b/apps/web/components/user-profile/graphs/main.tsx
@@ -25,7 +25,7 @@ export function Main(props: {
   // updated correctly in useEffect
   const mainGraph = useAppSelector((state) => state.graph)
   const state = {
-    graph: useState<ModtreeApiResponse.GraphFull>(mainGraph),
+    graph: useState<ModtreeApiResponse.Graph>(mainGraph),
   }
 
   useEffect(() => {
@@ -75,7 +75,7 @@ export function Main(props: {
 
 function GraphSection(props: {
   degrees: IDegree[]
-  graphs: ModtreeApiResponse.GraphFull[]
+  graphs: ModtreeApiResponse.Graph[]
 }) {
   const { degrees, graphs } = props
   return (

--- a/apps/web/store/graph.ts
+++ b/apps/web/store/graph.ts
@@ -23,7 +23,7 @@ export const graph = createSlice({
      * Overwrite the entire graph.
      * Meant to be used for initial page loads.
      */
-    setGraph: (graph, action: PayloadAction<ModtreeApiResponse.GraphFull>) => {
+    setGraph: (graph, action: PayloadAction<ModtreeApiResponse.Graph>) => {
       Object.entries(action.payload).forEach(([key, value]) => {
         graph[key] = value
       })

--- a/apps/web/store/initial-state.ts
+++ b/apps/web/store/initial-state.ts
@@ -3,7 +3,7 @@ import { empty } from '@modtree/utils'
 
 export const baseInitialState: ReduxState = {
   user: empty.UserFull,
-  degree: empty.Degree,
+  degree: empty.DegreeFull,
   graph: {
     ...empty.GraphFull,
     selectedCodes: [],

--- a/apps/web/store/initial-state.ts
+++ b/apps/web/store/initial-state.ts
@@ -3,7 +3,7 @@ import { empty } from '@modtree/utils'
 
 export const baseInitialState: ReduxState = {
   user: empty.UserFull,
-  degree: empty.DegreeFull,
+  degree: empty.Degree,
   graph: {
     ...empty.GraphFull,
     selectedCodes: [],

--- a/apps/web/store/initial-state.ts
+++ b/apps/web/store/initial-state.ts
@@ -5,7 +5,7 @@ export const baseInitialState: ReduxState = {
   user: empty.UserFull,
   degree: empty.Degree,
   graph: {
-    ...empty.GraphFull,
+    ...empty.Graph,
     selectedCodes: [],
   },
   modal: {

--- a/apps/web/store/types.d.ts
+++ b/apps/web/store/types.d.ts
@@ -10,7 +10,7 @@ import type { Pages, ContextMenuProps } from 'types'
 export type ReduxState = {
   user: ModtreeApiResponse.UserFull
   degree: ModtreeApiResponse.Degree
-  graph: ModtreeApiResponse.GraphFull & {
+  graph: ModtreeApiResponse.Graph & {
     selectedCodes: string[]
   }
   modal: {

--- a/apps/web/store/types.d.ts
+++ b/apps/web/store/types.d.ts
@@ -1,6 +1,5 @@
 import {
   IDegree,
-  IGraph,
   IModule,
   IModuleCondensed,
   IModuleFull,
@@ -10,7 +9,7 @@ import type { Pages, ContextMenuProps } from 'types'
 
 export type ReduxState = {
   user: ModtreeApiResponse.UserFull
-  degree: IDegree
+  degree: ModtreeApiResponse.Degree
   graph: ModtreeApiResponse.GraphFull & {
     selectedCodes: string[]
   }

--- a/apps/web/ui/search/degree/degree-picker.tsx
+++ b/apps/web/ui/search/degree/degree-picker.tsx
@@ -1,4 +1,4 @@
-import { Listbox, Switch } from '@headlessui/react'
+import { Listbox } from '@headlessui/react'
 import { IDegree, UseState } from '@modtree/types'
 import { CheckIcon, SelectorIcon } from '@/ui/icons'
 import { flatten } from '@/utils/tailwind'

--- a/apps/web/ui/search/degree/degree-picker.tsx
+++ b/apps/web/ui/search/degree/degree-picker.tsx
@@ -3,6 +3,7 @@ import { IDegree, UseState } from '@modtree/types'
 import { CheckIcon, SelectorIcon } from '@/ui/icons'
 import { flatten } from '@/utils/tailwind'
 import { flatten as flat } from '@modtree/utils'
+import { useEffect, useState } from 'react'
 
 export function DegreePicker(props: {
   degrees: IDegree[]
@@ -11,18 +12,27 @@ export function DegreePicker(props: {
   modulesDoingCodes: string[]
 }) {
   const [degree, setDegree] = props.select
+  const [remainingCodes, setRemainingCodes] = useState([])
 
   /**
-   * Filters away modulesDone and modulesDoing from degree.modules
+   * Filters away modulesDone and modulesDoing from degree.modules,
+   * and combines into a comma separated string of module codes.
    */
-  function getRemainingModuleCodes(degree: IDegree): string[] {
-    const modules = degree.modules.map(flat.module)
-    return modules.filter(
-      (m) =>
-        !props.modulesDoneCodes.includes(m) &&
-        !props.modulesDoingCodes.includes(m)
-    )
+  async function getRemainingModuleCodes(degree: IDegree): Promise<string[]> {
+    return degree.modules
+      .map(flat.module)
+      .filter(
+        (m) =>
+          !props.modulesDoneCodes.includes(m) &&
+          !props.modulesDoingCodes.includes(m)
+      )
   }
+
+  useEffect(() => {
+    getRemainingModuleCodes(degree).then((codes) => {
+      setRemainingCodes(codes)
+    })
+  }, [degree])
 
   return (
     <div className="flex-col space-y-2">
@@ -60,7 +70,7 @@ export function DegreePicker(props: {
         <p>
           The following remaining degree modules will be placed in the graph:
         </p>
-        <p className="mb-0">{getRemainingModuleCodes(degree).join(', ')}</p>
+        <p className="mb-0">{remainingCodes.join(', ')}</p>
       </div>
     </div>
   )

--- a/apps/web/ui/search/graph/graph-picker.tsx
+++ b/apps/web/ui/search/graph/graph-picker.tsx
@@ -11,8 +11,8 @@ import { updateUser } from '@/utils/rehydrate'
 import { useAppDispatch } from '@/store/redux'
 
 export function GraphPicker(props: {
-  graphs: ModtreeApiResponse.GraphFull[]
-  select: UseState<ModtreeApiResponse.GraphFull>
+  graphs: ModtreeApiResponse.Graph[]
+  select: UseState<ModtreeApiResponse.Graph>
 }) {
   const { user } = useUser()
   const [graph, setGraph] = props.select

--- a/apps/web/utils/graph/index.ts
+++ b/apps/web/utils/graph/index.ts
@@ -4,7 +4,7 @@ import { lowercaseAndDash } from '../string'
 /**
  * Given graph, returns degree-title/graph-title.
  */
-export function getUniqueGraphTitle(graph: ModtreeApiResponse.GraphFull) {
+export function getUniqueGraphTitle(graph: ModtreeApiResponse.Graph) {
   const degreeTitle = lowercaseAndDash(graph.degree.title)
   const graphTitle = lowercaseAndDash(graph.title)
   return degreeTitle + '/' + graphTitle
@@ -14,7 +14,7 @@ export function getUniqueGraphTitle(graph: ModtreeApiResponse.GraphFull) {
  * Returns true if module in modulesPlaced.
  */
 export function inModulesPlaced(
-  graph: ModtreeApiResponse.GraphFull,
+  graph: ModtreeApiResponse.Graph,
   moduleCode: string
 ) {
   return graph.modulesPlaced.includes(moduleCode)

--- a/apps/web/utils/graph/unique-title.spec.ts
+++ b/apps/web/utils/graph/unique-title.spec.ts
@@ -8,7 +8,6 @@ const graph: ModtreeApiResponse.GraphFull = {
   degree: {
     id: '',
     title: 'my degree',
-    modules: [],
   },
 }
 

--- a/apps/web/utils/graph/unique-title.spec.ts
+++ b/apps/web/utils/graph/unique-title.spec.ts
@@ -2,8 +2,8 @@ import { ModtreeApiResponse } from '@modtree/types'
 import { empty } from '@modtree/utils'
 import { getUniqueGraphTitle } from '.'
 
-const graph: ModtreeApiResponse.GraphFull = {
-  ...empty.GraphFull,
+const graph: ModtreeApiResponse.Graph = {
+  ...empty.Graph,
   title: 'my graph',
   degree: {
     id: '',

--- a/libs/types/src/api-response.ts
+++ b/libs/types/src/api-response.ts
@@ -65,6 +65,11 @@ export type GraphFull = Modify<
     user: string
     modulesPlaced: string[]
     modulesHidden: string[]
+    degree: {
+      // drop modules
+      id: string
+      title: string
+    }
   }
 >
 

--- a/libs/types/src/api-response.ts
+++ b/libs/types/src/api-response.ts
@@ -39,6 +39,11 @@ export type Degree = Modify<
 >
 
 /**
+ * Degree API respsonse
+ */
+export type DegreeFull = IDegree
+
+/**
  * Graph API respsonse
  */
 export type Graph = Modify<

--- a/libs/types/src/api-response.ts
+++ b/libs/types/src/api-response.ts
@@ -46,19 +46,6 @@ export type DegreeFull = IDegree
 /**
  * Graph API respsonse
  */
-export type Graph = Modify<
-  IGraph,
-  {
-    user: string
-    degree: string
-    modulesPlaced: string[]
-    modulesHidden: string[]
-  }
->
-
-/**
- * Graph API respsonse
- */
 export type GraphFull = Modify<
   IGraph,
   {

--- a/libs/types/src/api-response.ts
+++ b/libs/types/src/api-response.ts
@@ -46,7 +46,7 @@ export type DegreeFull = IDegree
 /**
  * Graph API respsonse
  */
-export type GraphFull = Modify<
+export type Graph = Modify<
   IGraph,
   {
     user: string

--- a/libs/utils/src/empty-entity.ts
+++ b/libs/utils/src/empty-entity.ts
@@ -119,5 +119,6 @@ export const empty = {
   UserFull,
   Graph,
   GraphFull,
+  Degree,
   DegreeFull,
 }

--- a/libs/utils/src/empty-entity.ts
+++ b/libs/utils/src/empty-entity.ts
@@ -1,7 +1,5 @@
 import {
   IUser,
-  IGraph,
-  IDegree,
   IModule,
   IModuleCondensed,
   IModuleFull,
@@ -62,18 +60,7 @@ const UserFull: ModtreeApiResponse.UserFull = {
   mainGraph: '',
 }
 
-const Graph: IGraph = {
-  title: '',
-  id: '',
-  user: User,
-  degree: DegreeFull,
-  modulesPlaced: [],
-  modulesHidden: [],
-  flowNodes: [],
-  flowEdges: [],
-}
-
-const GraphFull: ModtreeApiResponse.GraphFull = {
+const Graph: ModtreeApiResponse.Graph = {
   title: '',
   id: '',
   user: '',
@@ -118,7 +105,6 @@ export const empty = {
   User,
   UserFull,
   Graph,
-  GraphFull,
   Degree,
   DegreeFull,
 }

--- a/libs/utils/src/empty-entity.ts
+++ b/libs/utils/src/empty-entity.ts
@@ -19,9 +19,15 @@ const Module: IModule = {
   fulfillRequirements: [],
 }
 
+const Degree: ModtreeApiResponse.Degree = {
+  id: '',
+  modules: [], // string arr
+  title: '',
+}
+
 const DegreeFull: ModtreeApiResponse.DegreeFull = {
   id: '',
-  modules: [],
+  modules: [], // modules arr
   title: '',
 }
 
@@ -71,7 +77,7 @@ const GraphFull: ModtreeApiResponse.GraphFull = {
   title: '',
   id: '',
   user: '',
-  degree: DegreeFull,
+  degree: Degree,
   modulesPlaced: [],
   modulesHidden: [],
   flowNodes: [],

--- a/libs/utils/src/empty-entity.ts
+++ b/libs/utils/src/empty-entity.ts
@@ -19,7 +19,7 @@ const Module: IModule = {
   fulfillRequirements: [],
 }
 
-const Degree: IDegree = {
+const DegreeFull: ModtreeApiResponse.DegreeFull = {
   id: '',
   modules: [],
   title: '',
@@ -60,7 +60,7 @@ const Graph: IGraph = {
   title: '',
   id: '',
   user: User,
-  degree: Degree,
+  degree: DegreeFull,
   modulesPlaced: [],
   modulesHidden: [],
   flowNodes: [],
@@ -71,7 +71,7 @@ const GraphFull: ModtreeApiResponse.GraphFull = {
   title: '',
   id: '',
   user: '',
-  degree: Degree,
+  degree: DegreeFull,
   modulesPlaced: [],
   modulesHidden: [],
   flowNodes: [],
@@ -113,5 +113,5 @@ export const empty = {
   UserFull,
   Graph,
   GraphFull,
-  Degree,
+  DegreeFull,
 }

--- a/libs/utils/src/entity/flatten.spec.ts
+++ b/libs/utils/src/entity/flatten.spec.ts
@@ -101,6 +101,6 @@ describe('Graph', () => {
   })
 
   test('errors on invalid', () => {
-    expect(() => flatten.graph(new Graph())).toThrowError()
+    expect(() => flatten.graphFull(new Graph())).toThrowError()
   })
 })

--- a/libs/utils/src/entity/flatten.spec.ts
+++ b/libs/utils/src/entity/flatten.spec.ts
@@ -9,6 +9,7 @@ function makeModule(moduleCode: string) {
 
 const degree = new Degree()
 degree.id = 'degree_id'
+degree.title = 'degree_title'
 degree.modules = [makeModule('CS2030'), makeModule('CS2040')]
 
 const user = new User()
@@ -57,6 +58,7 @@ describe('Degree', () => {
   test('flattens one', () => {
     expect(flatten.degree(degree)).toEqual({
       id: 'degree_id',
+      title: 'degree_title',
       modules: ['CS2030', 'CS2040'],
     })
   })
@@ -86,12 +88,15 @@ describe('User', () => {
 
 describe('Graph', () => {
   test('flattens one', () => {
-    expect(flatten.graph(graph)).toEqual({
+    expect(flatten.graphFull(graph)).toEqual({
       id: 'graph_id',
       modulesHidden: ['CM1102', 'PC1432'],
       modulesPlaced: ['CS1231', 'MA2219'],
       user: 'user_id',
-      degree: 'degree_id',
+      degree: {
+        id: 'degree_id',
+        title: 'degree_title',
+      },
     })
   })
 

--- a/libs/utils/src/entity/flatten.spec.ts
+++ b/libs/utils/src/entity/flatten.spec.ts
@@ -88,7 +88,7 @@ describe('User', () => {
 
 describe('Graph', () => {
   test('flattens one', () => {
-    expect(flatten.graphFull(graph)).toEqual({
+    expect(flatten.graph(graph)).toEqual({
       id: 'graph_id',
       modulesHidden: ['CM1102', 'PC1432'],
       modulesPlaced: ['CS1231', 'MA2219'],
@@ -101,6 +101,6 @@ describe('Graph', () => {
   })
 
   test('errors on invalid', () => {
-    expect(() => flatten.graphFull(new Graph())).toThrowError()
+    expect(() => flatten.graph(new Graph())).toThrowError()
   })
 })

--- a/libs/utils/src/entity/index.ts
+++ b/libs/utils/src/entity/index.ts
@@ -76,11 +76,17 @@ export const flatten = {
    * @returns {ModtreeApiResponse.GraphFull}
    */
   graphFull(graph: Graph): ModtreeApiResponse.GraphFull {
+    const degree = {
+      title: graph.degree.title,
+      id: graph.degree.id,
+    }
+
     return {
       ...graph,
       user: graph.user.id,
       modulesHidden: graph.modulesHidden.map(flatten.module),
       modulesPlaced: graph.modulesPlaced.map(flatten.module),
+      degree,
     }
   },
 

--- a/libs/utils/src/entity/index.ts
+++ b/libs/utils/src/entity/index.ts
@@ -59,23 +59,6 @@ export const flatten = {
    * @returns {ModtreeApiResponse.Graph}
    */
   graph(graph: Graph): ModtreeApiResponse.Graph {
-    return {
-      ...graph,
-      id: graph.id,
-      user: graph.user.id,
-      degree: graph.degree.id,
-      modulesHidden: graph.modulesHidden.map(flatten.module),
-      modulesPlaced: graph.modulesPlaced.map(flatten.module),
-    }
-  },
-
-  /**
-   * flattens a graph to response shape
-   *
-   * @param {Graph} graph
-   * @returns {ModtreeApiResponse.GraphFull}
-   */
-  graphFull(graph: Graph): ModtreeApiResponse.GraphFull {
     const degree = {
       title: graph.degree.title,
       id: graph.degree.id,


### PR DESCRIPTION
### Summary of changes

- Retire `GraphFull` and related types
- Frontend `Graph` states do not have degree modules
- Frontend `Degree` has flattened modules
- Frontend API abstraction uses `ModtreeApiResponse` in all of its return types
- Minor refactoring

### Testing

- Regular testing
