### PR TITLE
fix: frontend selection glitching

### DIFF
--- a/libs/utils/src/flow/get-nodes.ts
+++ b/libs/utils/src/flow/get-nodes.ts
@@ -44,6 +44,8 @@ export function getFlowNodes(
   })
   return nodes.map((node) => ({
     ...node,
+    // unselect nodes
+    selected: undefined,
     position: positions[node.id],
   }))
 }


### PR DESCRIPTION
### Summary of changes

- Glitch was due to nodes selected states being persisted in `getFlowNodes` in `redrawGraph`
- Remove persistence of selected state

### Testing

- On modtree.vercel.app, selecting one node and dragging can sometimes persist the selected state. So you can try repeatedly doing this action to ensure the glitch happens.
- Repeat this action for this branch. The glitch should not happen.
