### PR TITLE
fix: check modules in cache defined

### DIFF
--- a/apps/web/components/user-profile/degrees/add-new.tsx
+++ b/apps/web/components/user-profile/degrees/add-new.tsx
@@ -30,7 +30,7 @@ function SelectedModules(props: { modules: string[] }) {
               >
                 <span className="font-semibold">{code}</span>
                 <span className="mx-1">/</span>
-                {module.title}
+                {module && module.title}
               </Row.Module>
             )
           })}

--- a/apps/web/components/user-profile/modules/main.tsx
+++ b/apps/web/components/user-profile/modules/main.tsx
@@ -47,7 +47,7 @@ export function Main(props: { setPage: SetState<Pages['Modules']> }) {
                     <Row.Module key={dashed(code, index)}>
                       <span className="font-semibold">{code}</span>
                       <span className="mx-1">/</span>
-                      {module.title}
+                      {module && module.title}
                     </Row.Module>
                   )
                 })}
@@ -78,7 +78,7 @@ export function Main(props: { setPage: SetState<Pages['Modules']> }) {
                     <Row.Module key={dashed(code, index)}>
                       <span className="font-semibold">{code}</span>
                       <span className="mx-1">/</span>
-                      {module.title}
+                      {module && module.title}
                     </Row.Module>
                   )
                 })}

--- a/apps/web/components/user-profile/modules/selected-modules.tsx
+++ b/apps/web/components/user-profile/modules/selected-modules.tsx
@@ -20,7 +20,7 @@ export function SelectedModules(props: { modules: string[] }) {
               >
                 <span className="font-semibold">{code}</span>
                 <span className="mx-1">/</span>
-                {module.title}
+                {module && module.title}
               </Row.Module>
             )
           })}


### PR DESCRIPTION
### Summary of changes

- As part of #320, user modules are flattened and we refer to cache.
- This change ensures that the module in cache is defined before trying to access

### Testing

- Check add degrees panel, modules done/doing panel. The app should not crash.
