### PR TITLE
test(e2e): modules panel

### DIFF
--- a/apps/web-e2e/cypress/integration/modules.cy.ts
+++ b/apps/web-e2e/cypress/integration/modules.cy.ts
@@ -21,21 +21,23 @@ describe('module nodes', () => {
     // sign in
     cy.get('a[href="/api/auth/login"]').click()
     cy.wait('@signInToModtree')
-  })
 
-  it('all checks', () => {
     // getUser
     cy.intercept('/user/*/get-full').as('getUser')
     cy.wait('@getUser')
 
     // open modules panel
-    cy.get('[id="modtree-user-circle"]').click()
-    cy.contains('Your profile').click()
-    cy.contains('Modules').click()
+    cy.get('[id="modtree-user-circle"]').then((icon) => {
+      icon.click()
+      cy.contains('Your profile').click()
+      cy.contains('Modules').click()
 
-    // preset count
-    checkLengths()
+      // preset count
+      checkLengths()
+    })
+  })
 
+  it('Adds to modules done', () => {
     // add LAC1201 to modules done
     cy.get('[data-cy="modify-done"]').click()
     cy.get('[data-cy="add-done-search"]').type('LAC1201')
@@ -44,7 +46,9 @@ describe('module nodes', () => {
 
     doneCount++
     checkLengths()
+  })
 
+  it('Adds to modules doing', () => {
     // add LAC2201 to modules doing
     cy.get('[data-cy="modify-doing"]').click()
     cy.get('[data-cy="add-doing-search"]').type('LAC2201')
@@ -53,7 +57,9 @@ describe('module nodes', () => {
 
     doingCount++
     checkLengths()
+  })
 
+  it('Removes from modules done', () => {
     // remove last module from modules done (LAC1201)
     cy.get('[data-cy="modify-done"]').click()
     cy.get('[data-cy="build-list"]').should('be.visible')
@@ -63,7 +69,9 @@ describe('module nodes', () => {
 
     doneCount--
     checkLengths()
+  })
 
+  it('Removes from modules doing', () => {
     // remove last module from modules doing (LAC2201)
     cy.get('[data-cy="modify-doing"]').click()
     cy.get('[data-cy="build-list"]').should('be.visible')
@@ -73,7 +81,5 @@ describe('module nodes', () => {
 
     doingCount--
     checkLengths()
-
-    // refresh page and the above should be persisted
   })
 })

--- a/apps/web-e2e/cypress/integration/modules.cy.ts
+++ b/apps/web-e2e/cypress/integration/modules.cy.ts
@@ -1,0 +1,35 @@
+// these are our presets upon initializing a new user
+const modulesDoneCount = 7
+const modulesDoingCount = 9
+
+describe('module nodes', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:3000/')
+    cy.intercept('GET', '/api/auth/login').as('signInToModtree')
+
+    // sign in
+    cy.get('a[href="/api/auth/login"]').click()
+    cy.wait('@signInToModtree')
+  })
+
+  it('all checks', () => {
+    // getUser
+    cy.intercept('/user/*/get-full').as('getUser')
+    cy.wait('@getUser')
+
+    // open modules panel
+    cy.get('[id="modtree-user-circle"]').click()
+    cy.contains('Your profile').click()
+    cy.contains('Modules').click()
+
+    // preset count
+    cy.get('[data-cy="done-section"]')
+      .children()
+      .its('length')
+      .should('eq', modulesDoneCount)
+    cy.get('[data-cy="doing-section"]')
+      .children()
+      .its('length')
+      .should('eq', modulesDoingCount)
+  })
+})

--- a/apps/web-e2e/cypress/integration/modules.cy.ts
+++ b/apps/web-e2e/cypress/integration/modules.cy.ts
@@ -1,6 +1,17 @@
 // these are our presets upon initializing a new user
-const modulesDoneCount = 7
-const modulesDoingCount = 9
+let doneCount = 7
+let doingCount = 9
+
+function checkLengths() {
+  cy.get('[data-cy="done-section"]')
+    .children()
+    .its('length')
+    .should('eq', doneCount)
+  cy.get('[data-cy="doing-section"]')
+    .children()
+    .its('length')
+    .should('eq', doingCount)
+}
 
 describe('module nodes', () => {
   beforeEach(() => {
@@ -23,13 +34,46 @@ describe('module nodes', () => {
     cy.contains('Modules').click()
 
     // preset count
-    cy.get('[data-cy="done-section"]')
-      .children()
-      .its('length')
-      .should('eq', modulesDoneCount)
-    cy.get('[data-cy="doing-section"]')
-      .children()
-      .its('length')
-      .should('eq', modulesDoingCount)
+    checkLengths()
+
+    // add LAC1201 to modules done
+    cy.get('[data-cy="modify-done"]').click()
+    cy.get('[data-cy="add-done-search"]').type('LAC1201')
+    cy.get('[id^=headlessui-combobox-option]').contains('Chinese 1').click()
+    cy.get('button').contains('Save changes').click()
+
+    doneCount++
+    checkLengths()
+
+    // add LAC2201 to modules doing
+    cy.get('[data-cy="modify-doing"]').click()
+    cy.get('[data-cy="add-doing-search"]').type('LAC2201')
+    cy.get('[id^=headlessui-combobox-option]').contains('Chinese 2').click()
+    cy.get('button').contains('Save changes').click()
+
+    doingCount++
+    checkLengths()
+
+    // remove last module from modules done (LAC1201)
+    cy.get('[data-cy="modify-done"]').click()
+    cy.get('[data-cy="build-list"]').should('be.visible')
+    // get trash button of last module in list
+    cy.get('[data-cy="build-list"] > div').last().find('button').click()
+    cy.get('button').contains('Save changes').click()
+
+    doneCount--
+    checkLengths()
+
+    // remove last module from modules doing (LAC2201)
+    cy.get('[data-cy="modify-doing"]').click()
+    cy.get('[data-cy="build-list"]').should('be.visible')
+    // get trash button of last module in list
+    cy.get('[data-cy="build-list"] > div').last().find('button').click()
+    cy.get('button').contains('Save changes').click()
+
+    doingCount--
+    checkLengths()
+
+    // refresh page and the above should be persisted
   })
 })

--- a/apps/web/components/user-profile/modules/add-doing.tsx
+++ b/apps/web/components/user-profile/modules/add-doing.tsx
@@ -29,10 +29,10 @@ export function AddDoing(props: { setPage: SetState<Pages['Modules']> }) {
       >
         <h6>Modules</h6>
         <div className="flex flex-row space-x-2 mb-4">
-          <SettingsSearchBox />
+          <SettingsSearchBox cypress="add-doing-search" />
           <Button>Add Module</Button>
         </div>
-        <SelectedModules modules={buildList} />
+        <SelectedModules cypress="build-list" modules={buildList} />
       </SettingsSection>
       <div className="flex flex-row-reverse">
         <Button color="green" onClick={() => confirm()}>

--- a/apps/web/components/user-profile/modules/add-done.tsx
+++ b/apps/web/components/user-profile/modules/add-done.tsx
@@ -29,10 +29,10 @@ export function AddDone(props: { setPage: SetState<Pages['Modules']> }) {
       >
         <h6>Modules</h6>
         <div className="flex flex-row space-x-2 mb-4">
-          <SettingsSearchBox />
+          <SettingsSearchBox cypress="add-done-search" />
           <Button>Add Module</Button>
         </div>
-        <SelectedModules modules={buildList} />
+        <SelectedModules cypress="build-list" modules={buildList} />
       </SettingsSection>
       <div className="flex flex-row-reverse">
         <Button color="green" onClick={() => confirm()}>

--- a/apps/web/components/user-profile/modules/main.tsx
+++ b/apps/web/components/user-profile/modules/main.tsx
@@ -36,11 +36,15 @@ export function Main(props: { setPage: SetState<Pages['Modules']> }) {
             dispatch(setBuildList(user.modulesDoing))
             props.setPage('add-doing')
           }}
+          cypress="modify-doing"
         >
           {hasModules.doing ? (
             <>
               <p>{text.moduleListSection.doing.summary}</p>
-              <div className="ui-rectangle flex flex-col overflow-hidden">
+              <div
+                data-cy="doing-section"
+                className="ui-rectangle flex flex-col overflow-hidden"
+              >
                 {user.modulesDoing.map((code, index) => {
                   const module = cache.modules[code]
                   return (
@@ -67,11 +71,15 @@ export function Main(props: { setPage: SetState<Pages['Modules']> }) {
             dispatch(setBuildList(user.modulesDone))
             props.setPage('add-done')
           }}
+          cypress="modify-done"
         >
           {hasModules.done ? (
             <>
               <p>{text.moduleListSection.done.summary}</p>
-              <div className="ui-rectangle flex flex-col overflow-hidden">
+              <div
+                data-cy="done-section"
+                className="ui-rectangle flex flex-col overflow-hidden"
+              >
                 {user.modulesDone.map((code, index) => {
                   const module = cache.modules[code]
                   return (

--- a/apps/web/components/user-profile/modules/selected-modules.tsx
+++ b/apps/web/components/user-profile/modules/selected-modules.tsx
@@ -3,13 +3,19 @@ import { removeFromBuildList } from '@/store/search'
 import { dashed } from '@/utils/array'
 import { Row } from '@/ui/settings/lists/rows'
 
-export function SelectedModules(props: { modules: string[] }) {
+export function SelectedModules(props: {
+  modules: string[]
+  cypress?: string
+}) {
   const dispatch = useAppDispatch()
   const cache = useAppSelector((state) => state.cache)
   return (
     <>
       {props.modules.length !== 0 && (
-        <div className="ui-rectangle flex flex-col overflow-hidden">
+        <div
+          className="ui-rectangle flex flex-col overflow-hidden"
+          data-cy={props.cypress}
+        >
           {props.modules.map((code, index) => {
             const module = cache.modules[code]
             return (

--- a/apps/web/ui/search/module/container.tsx
+++ b/apps/web/ui/search/module/container.tsx
@@ -15,6 +15,7 @@ export function SearchContainer(props: {
   inputContainerClass?: string
   hideResults?: boolean
   searchIcon?: boolean
+  cypress?: string
 }) {
   const [selected] = props.selectState
   return (
@@ -25,6 +26,7 @@ export function SearchContainer(props: {
         inputClass={props.inputClass}
         inputContainerClass={props.inputContainerClass}
         searchIcon={props.searchIcon}
+        cypress={props.cypress}
       />
       <div className="relative w-full">
         {!props.hideResults && (

--- a/apps/web/ui/search/module/index.tsx
+++ b/apps/web/ui/search/module/index.tsx
@@ -37,7 +37,7 @@ export function RootSearchBox() {
   )
 }
 
-export function SettingsSearchBox() {
+export function SettingsSearchBox(props: { cypress?: string }) {
   const dispatch = useAppDispatch()
   /**
    * only changes upon clicking on the search result
@@ -67,6 +67,7 @@ export function SettingsSearchBox() {
         onSelect={onSelect}
         inputContainerClass="h-full shadow-none"
         inputClass="h-full shadow-none"
+        cypress={props.cypress}
       />
     </div>
   )

--- a/apps/web/ui/search/module/input.tsx
+++ b/apps/web/ui/search/module/input.tsx
@@ -15,6 +15,7 @@ export function SearchInput<T>(props: {
   clear: () => AnyAction
   set: ActionCreatorWithOptionalPayload<T[], string>
   searchIcon?: boolean
+  cypress?: string
 }) {
   const { inputClass, inputContainerClass } = props
   const [query, setQuery] = useState('')
@@ -41,6 +42,7 @@ export function SearchInput<T>(props: {
           )}
           placeholder="Search for a module"
           onChange={(event) => setQuery(event.target.value)}
+          data-cy={props.cypress}
         />
         {props.searchIcon && (
           <Combobox.Button className="flex items-center px-3">

--- a/apps/web/ui/settings/lists/base.tsx
+++ b/apps/web/ui/settings/lists/base.tsx
@@ -15,6 +15,7 @@ type SettingsSectionProps = {
   onAddClick?: () => void
   children: ReactElement | ReactElement[]
   className?: string
+  cypress?: string
 } & TitleProps
 
 const Title = (props: TitleProps) => {
@@ -43,6 +44,7 @@ export function SettingsSection(props: SettingsSectionProps) {
             <Button
               color={props.addButtonColor || 'green'}
               onClick={props.onAddClick}
+              data-cy={props.cypress}
             >
               {props.addButtonText}
             </Button>


### PR DESCRIPTION
### Summary of changes

Working towards #332

- Add e2e test for modules panel (add/remove modules done/doing)
- Add `data-cy` attribute on base HTML elements for the sole purpose of being selectors in cypress tests

### Testing

- `yarn dev:server`
- `yarn e2e`
- Select `modules.cy.ts`
