### PR TITLE
fix: edits for PR #334

### DIFF
--- a/apps/server/src/trpc/user.ts
+++ b/apps/server/src/trpc/user.ts
@@ -41,7 +41,7 @@ export const user = createRouter()
   .query('get-full', {
     input: z.string().uuid(),
     async resolve(req) {
-      return api.userRepo.findOneById(req.input).then(flatten.userFull)
+      return api.userRepo.findOneFullById(req.input).then(flatten.userFull)
     },
   })
 

--- a/apps/web/ui/search/degree/degree-picker.tsx
+++ b/apps/web/ui/search/degree/degree-picker.tsx
@@ -2,9 +2,8 @@ import { Listbox } from '@headlessui/react'
 import { IDegree, UseState } from '@modtree/types'
 import { CheckIcon, SelectorIcon } from '@/ui/icons'
 import { flatten } from '@/utils/tailwind'
-import { useEffect } from 'react'
-import { api } from 'api'
-import { useAppSelector } from '@/store/redux'
+import { useEffect, useState } from 'react'
+import { flatten as flat } from '@modtree/utils'
 
 export function DegreePicker(props: {
   degrees: IDegree[]
@@ -13,10 +12,27 @@ export function DegreePicker(props: {
   modulesDoingCodes: string[]
 }) {
   const [degree, setDegree] = props.select
-  const { buildList } = useAppSelector((state) => state.search)
+
+  const [remainingCodes, setRemainingCodes] = useState<string[]>([])
+
+  /**
+   * Filters away modulesDone and modulesDoing from degree.modules,
+   * and combines into a comma separated string of module codes.
+   */
+  async function getRemainingModuleCodes(degree: IDegree): Promise<string[]> {
+    return degree.modules
+      .map(flat.module)
+      .filter(
+        (m) =>
+          !props.modulesDoneCodes.includes(m) &&
+          !props.modulesDoingCodes.includes(m)
+      )
+  }
 
   useEffect(() => {
-    api.degree.setBuildTarget(degree.id)
+    getRemainingModuleCodes(degree).then((codes) => {
+      setRemainingCodes(codes)
+    })
   }, [degree])
 
   return (
@@ -55,7 +71,7 @@ export function DegreePicker(props: {
         <p>
           The following remaining degree modules will be placed in the graph:
         </p>
-        <p className="mb-0">{buildList.join(', ')}</p>
+        <p className="mb-0">{remainingCodes.join(', ')}</p>
       </div>
     </div>
   )

--- a/libs/repos/src/user/repo.ts
+++ b/libs/repos/src/user/repo.ts
@@ -49,6 +49,20 @@ export class UserRepository extends BaseRepo<User> implements IUserRepository {
       relations: this.relations,
     })
 
+  findOneFullById = async (id: string) =>
+    this.findOne({
+      where: { id },
+      relations: {
+        ...this.relations,
+        savedDegrees: {
+          modules: true,
+        },
+        mainDegree: {
+          modules: true,
+        },
+      },
+    })
+
   /**
    * Adds a User to DB
    *

--- a/libs/types/src/repository.ts
+++ b/libs/types/src/repository.ts
@@ -186,6 +186,13 @@ export interface IUserRepository extends IBaseRepository<IUser> {
    */
   findOneById(id: string): Promise<IUser>
   /**
+   * finds a user full by id
+   *
+   * @param id
+   * @returns user
+   */
+  findOneFullById(id: string): Promise<IUser>
+  /**
    * delete all users
    *
    * @returns delete result


### PR DESCRIPTION
### Summary of changes

Note: we can instead fetch degrees when we need them, instead of loading it as part of `user/get-full`.

- Frontend user state contains unflattened degrees
- Degree section in graph add new shows remaining modules to be placed in the graph

### Testing

- Check debug panel. Redux user should show unflattened degrees
- Degree section in graph add new should not show modules that appear in modules done/doing section
