### PR TITLE
feat: remove graph, set module as not done

### DIFF
--- a/apps/server/src/trpc/user.ts
+++ b/apps/server/src/trpc/user.ts
@@ -133,8 +133,11 @@ export const user = createRouter()
       userId: z.string().uuid(),
       graphId: z.string().uuid(),
     }),
-    async resolve(_req) {
-      return 'NOT IMPLEMENTED YET'
+    async resolve(req) {
+      return api.userRepo
+        .findOneById(req.input.userId)
+        .then((user) => api.userRepo.removeGraph(user, req.input.graphId))
+        .then(flatten.user)
     },
   })
 

--- a/apps/web/components/menu-items.ts
+++ b/apps/web/components/menu-items.ts
@@ -53,6 +53,14 @@ const flowNodeContextMenu: MenuItem[] = [
     },
   },
   {
+    text: 'Mark as not done',
+    callback: (e) => {
+      if (!e) return
+      const user = store.getState().user
+      api.user.setModuleStatus(user.id, [e.id], ModuleStatus.NOT_TAKEN)
+    },
+  },
+  {
     text: 'Remove',
     callback: async (e) => {
       if (!e) return

--- a/libs/repos/src/user/repo.ts
+++ b/libs/repos/src/user/repo.ts
@@ -295,6 +295,25 @@ export class UserRepository extends BaseRepo<User> implements IUserRepository {
   }
 
   /**
+   * Removes a graph among saved graphs of a user.
+   *
+   * @param {User} user
+   * @param {string} graphId
+   * @returns {Promise<User>}
+   */
+  async removeGraph(user: User, graphId: string): Promise<User> {
+    // 1. find graph among user's savedGraphs
+    const filtered = user.savedGraphs.filter((graph) => graph.id !== graphId)
+    // 2. find graph among user's savedGraphs
+    if (filtered.length === user.savedGraphs.length) {
+      throw new Error('Graph not found in User')
+    }
+    // 3. update entity and save
+    user.savedGraphs = filtered
+    return this.save(user)
+  }
+
+  /**
    * Sets modulesDone/modulesDoing.
    *
    * @param {User} _user

--- a/libs/types/src/repository.ts
+++ b/libs/types/src/repository.ts
@@ -319,6 +319,14 @@ export interface IUserRepository extends IBaseRepository<IUser> {
    * @returns user
    */
   insertGraphs(user: IUser, graphIds: string[]): Promise<IUser>
+  /**
+   * removes a graph from a user's list of saved graphs
+   *
+   * @param user
+   * @param graphId
+   * @returns user
+   */
+  removeGraph(user: IUser, graphId: string): Promise<IUser>
 }
 
 /**


### PR DESCRIPTION
### Summary of changes

- Can now remove graph. Not allowed to remove the main graph.
- Can set module as not done in the node context menu.

### Testing

- Add a new graph. You should not be able to remove your set graph, but you can remove the other graph.
- Try setting a done/doing module as not done through the node context menu. It will be removed from user panel modules done/doing

### Cannot remove main graph

![image](https://user-images.githubusercontent.com/20338724/179382149-029ed601-d236-41e4-9fd3-3cf8706fa987.png)

