### PR TITLE
feat: flatten user degrees

### DIFF
--- a/apps/server/src/api/user.ts
+++ b/apps/server/src/api/user.ts
@@ -1,5 +1,5 @@
 import { Api } from '@modtree/repos'
-import { CustomReqBody, CustomReqQuery } from '@modtree/types'
+import { CustomReqQuery } from '@modtree/types'
 import { emptyInit, flatten } from '@modtree/utils'
 import { Request } from 'express'
 
@@ -75,7 +75,7 @@ export class UserApi {
           mainGraph: true,
         },
       })
-      .then(flatten.userFull)
+      .then(flatten.user)
   }
 
   /**
@@ -113,7 +113,7 @@ export class UserApi {
   static login = (api: Api) => async (req: Request) => {
     const authZeroId = req.params.authZeroId
     const { email } = req.body
-    return api.userLogin(authZeroId, email).then(flatten.userFull)
+    return api.userLogin(authZeroId, email).then(flatten.user)
   }
 
   /**

--- a/apps/server/src/trpc/user.ts
+++ b/apps/server/src/trpc/user.ts
@@ -41,7 +41,7 @@ export const user = createRouter()
   .query('get-full', {
     input: z.string().uuid(),
     async resolve(req) {
-      return api.userRepo.findOneById(req.input).then(flatten.userFull)
+      return api.userRepo.findOneById(req.input).then(flatten.user)
     },
   })
 
@@ -175,6 +175,6 @@ export const user = createRouter()
     async resolve(req) {
       return api
         .userLogin(req.input.authZeroId, req.input.email)
-        .then(flatten.userFull)
+        .then(flatten.user)
     },
   })

--- a/apps/web-e2e/cypress/integration/graph/add-and-remove.cy.ts
+++ b/apps/web-e2e/cypress/integration/graph/add-and-remove.cy.ts
@@ -15,7 +15,7 @@ describe('add-and-remove', () => {
      */
     // getUser has completed
     // Wait for store to load
-    cy.wait(5000)
+    cy.wait(2000)
     cy.window()
       .its('store')
       .invoke('getState')

--- a/apps/web-e2e/cypress/support/commands.ts
+++ b/apps/web-e2e/cypress/support/commands.ts
@@ -66,6 +66,10 @@ Cypress.Commands.add('addGraphModule', (moduleCode: string, title: string) => {
     })
     .then(() => {
       cy.get('button').contains('Add to graph').click()
+      /**
+       * wait for module to be added to graph
+       */
+      cy.wait(3000)
     })
 })
 

--- a/apps/web-e2e/cypress/support/commands.ts
+++ b/apps/web-e2e/cypress/support/commands.ts
@@ -49,8 +49,12 @@ Cypress.Commands.add('login', () => {
   })
 
   // 3. wait for user to load
-  cy.intercept('/trpc/user/get-full**').as('getUser')
-  cy.wait('@getUser')
+  cy.wait(2000)
+  /**
+   * Correct alternative getUser is unstable
+   */
+  // cy.intercept('/trpc/user/get-full**').as('getUser')
+  // cy.wait('@getUser')
 })
 
 Cypress.Commands.add('addGraphModule', (moduleCode: string, title: string) => {

--- a/apps/web/api/degree.ts
+++ b/apps/web/api/degree.ts
@@ -3,7 +3,7 @@ import { addToBuildList, setBuildList } from '@/store/search'
 import { updateUser } from '@/utils/rehydrate'
 import { trpc } from '@/utils/trpc'
 import { InitDegreeProps, ModtreeApiResponse } from '@modtree/types'
-
+import { api } from 'api'
 import { BaseApi } from './base-api'
 
 export class DegreeApi extends BaseApi {
@@ -34,10 +34,13 @@ export class DegreeApi extends BaseApi {
    * sets frontend current build target
    */
   async setBuildTarget(degreeId: string) {
-    return trpc.query('degree/get-full', degreeId).then((degree) => {
-      this.dispatch(addModulesToCache(degree.modules))
-      this.dispatch(setBuildList(degree.modules.map((m) => m.moduleCode)))
-    })
+    return trpc
+      .query('degree', degreeId)
+      .then((degree) => api.module.getByCodes(degree.modules))
+      .then((modules) => {
+        this.dispatch(addModulesToCache(modules))
+        this.dispatch(setBuildList(modules.map((m) => m.moduleCode)))
+      })
   }
 
   /**

--- a/apps/web/api/user.ts
+++ b/apps/web/api/user.ts
@@ -96,4 +96,14 @@ export class UserApi extends BaseApi {
   ): Promise<ModtreeApiResponse.User> {
     return trpc.mutation('user/insert-graphs', { userId, graphIds: [graphId] })
   }
+
+  /**
+   * remove degree
+   */
+  async removeGraph(
+    userId: string,
+    graphId: string
+  ): Promise<ModtreeApiResponse.User> {
+    return trpc.mutation('user/remove-graph', { userId, graphId })
+  }
 }

--- a/apps/web/api/user.ts
+++ b/apps/web/api/user.ts
@@ -11,7 +11,7 @@ export class UserApi extends BaseApi {
    * @param {string} userId
    * @returns {Promise<User>}
    */
-  async getById(userId: string): Promise<ModtreeApiResponse.UserFull> {
+  async getById(userId: string): Promise<ModtreeApiResponse.User> {
     return trpc.query('user/get-full', userId)
   }
 
@@ -25,7 +25,7 @@ export class UserApi extends BaseApi {
   async login(
     authZeroId: string,
     email: string
-  ): Promise<ModtreeApiResponse.UserFull> {
+  ): Promise<ModtreeApiResponse.User> {
     return trpc.mutation('user/login', { authZeroId, email }).then((user) => {
       this.dispatch(setUser(user))
       return user

--- a/apps/web/components/user-profile/degrees/main.tsx
+++ b/apps/web/components/user-profile/degrees/main.tsx
@@ -3,20 +3,31 @@ import { text } from 'text'
 import { SettingsSection } from '@/ui/settings/lists/base'
 import { Row } from '@/ui/settings/lists/rows'
 import { dashed } from '@/utils/array'
-import { Dispatch, SetStateAction } from 'react'
+import { Dispatch, SetStateAction, useEffect, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '@/store/redux'
 import { clearBuildList, setBuildId, setBuildTitle } from '@/store/search'
 import { useUser } from '@/utils/auth0'
 import { updateUser } from '@/utils/rehydrate'
 import { trpc } from '@/utils/trpc'
+import { ModtreeApiResponse } from '@modtree/types'
 
 export function Main(props: {
   setPage: Dispatch<SetStateAction<Pages['Degrees']>>
 }) {
   const dispatch = useAppDispatch()
-  const degrees = useAppSelector((state) => state.user.savedDegrees)
-  const hasDegree = degrees.length !== 0
+
+  // Get IDs
+  const degreeIds = useAppSelector((state) => state.user.savedDegrees)
+  const hasDegree = degreeIds.length !== 0
   const { user } = useUser()
+
+  // Load full degrees
+  const [degrees, setDegrees] = useState<ModtreeApiResponse.Degree[]>([])
+  useEffect(() => {
+    trpc.query('degrees', degreeIds).then((degrees) => {
+      setDegrees(degrees)
+    })
+  }, [degreeIds])
 
   async function removeDegree(degreeId: string) {
     const userId = user?.modtreeId

--- a/apps/web/components/user-profile/graphs/add-new.tsx
+++ b/apps/web/components/user-profile/graphs/add-new.tsx
@@ -12,8 +12,6 @@ import { trpc } from '@/utils/trpc'
 
 export function AddNew(props: { setPage: SetState<Pages['Graphs']> }) {
   const degrees = useAppSelector((state) => state.user.savedDegrees)
-  const modulesDone = useAppSelector((state) => state.user.modulesDone)
-  const modulesDoing = useAppSelector((state) => state.user.modulesDoing)
 
   const { user } = useUser()
 
@@ -58,42 +56,13 @@ export function AddNew(props: { setPage: SetState<Pages['Graphs']> }) {
       >
         <h6>Title</h6>
         <Input className="w-full mb-4" state={state.title} grayed />
-        <h6>Modules</h6>
-        <Modules
-          modulesDoneCodes={modulesDone}
-          modulesDoingCodes={modulesDoing}
-        />
         <h6>Degree</h6>
-        <DegreePicker
-          degrees={degrees}
-          select={state.degree}
-          modulesDoneCodes={modulesDone}
-          modulesDoingCodes={modulesDoing}
-        />
+        <DegreePicker degrees={degrees} select={state.degree} />
       </SettingsSection>
       <div className="flex flex-row-reverse">
         <Button color="green" onClick={saveGraph}>
           Save graph
         </Button>
-      </div>
-    </div>
-  )
-}
-
-function Modules(props: {
-  modulesDoneCodes: string[]
-  modulesDoingCodes: string[]
-}) {
-  return (
-    <div className="mb-4">
-      <div className="bg-gray-200 p-2 rounded-xl flex-col space-y-2">
-        <p>The following modules will be placed in the graph:</p>
-        <p className="mb-0">
-          <b>Done:</b> {props.modulesDoneCodes.join(', ')}
-        </p>
-        <p className="mb-0">
-          <b>Doing:</b> {props.modulesDoingCodes.join(', ')}
-        </p>
       </div>
     </div>
   )

--- a/apps/web/components/user-profile/graphs/add-new.tsx
+++ b/apps/web/components/user-profile/graphs/add-new.tsx
@@ -1,8 +1,8 @@
 import { SettingsSection } from '@/ui/settings/lists/base'
 import { Button } from '@/ui/buttons'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Input } from '@/ui/html'
-import { IDegree, InitGraphProps, SetState } from '@modtree/types'
+import { InitGraphProps, ModtreeApiResponse, SetState } from '@modtree/types'
 import { Pages } from 'types'
 import { DegreePicker } from '@/ui/search/degree/degree-picker'
 import { useAppSelector } from '@/store/redux'
@@ -11,22 +11,38 @@ import { updateUser } from '@/utils/rehydrate'
 import { trpc } from '@/utils/trpc'
 
 export function AddNew(props: { setPage: SetState<Pages['Graphs']> }) {
-  const degrees = useAppSelector((state) => state.user.savedDegrees)
+  // Get IDs
+  const degreeIds = useAppSelector((state) => state.user.savedDegrees)
+
+  // Load full degrees
+  const [degrees, setDegrees] = useState<ModtreeApiResponse.Degree[]>([])
+  const [loaded, setLoaded] = useState<boolean>(false)
+  useEffect(() => {
+    trpc.query('degrees', degreeIds).then((degrees) => {
+      setDegrees(degrees)
+      // actually set the degree
+      state.degree[1](degrees[0])
+      setLoaded(true)
+    })
+  }, [degreeIds])
 
   const { user } = useUser()
 
   const state = {
     title: useState<string>(''),
-    degree: useState<IDegree>(degrees[0]),
+    // actually undefined here
+    degree: useState<ModtreeApiResponse.Degree>(degrees[0]),
   }
 
   async function saveGraph() {
     const userId = user?.modtreeId
     if (!userId) return
+    const degreeId = state.degree[0].id
+    if (!degreeId) return
     const graphProps: InitGraphProps = {
       title: state.title[0],
       userId,
-      degreeId: state.degree[0].id,
+      degreeId,
     }
     // frontend validation
     if (graphProps.title === '') {
@@ -57,7 +73,11 @@ export function AddNew(props: { setPage: SetState<Pages['Graphs']> }) {
         <h6>Title</h6>
         <Input className="w-full mb-4" state={state.title} grayed />
         <h6>Degree</h6>
-        <DegreePicker degrees={degrees} select={state.degree} />
+        {loaded ? (
+          <DegreePicker degrees={degrees} select={state.degree} />
+        ) : (
+          <></>
+        )}
       </SettingsSection>
       <div className="flex flex-row-reverse">
         <Button color="green" onClick={saveGraph}>

--- a/apps/web/components/user-profile/graphs/main.tsx
+++ b/apps/web/components/user-profile/graphs/main.tsx
@@ -6,7 +6,7 @@ import { text } from 'text'
 import { Row } from '@/ui/settings/lists/rows'
 import { GraphIcon } from '@/ui/icons'
 import { EmptyBox } from '@/ui/settings/empty-box'
-import { IDegree, ModtreeApiResponse } from '@modtree/types'
+import { ModtreeApiResponse } from '@modtree/types'
 import { lowercaseAndDash } from '@/utils/string'
 import { Pages } from 'types'
 import { GraphPicker } from '@/ui/search/graph/graph-picker'
@@ -17,12 +17,21 @@ import { updateUser } from '@/utils/rehydrate'
 export function Main(props: {
   setPage: Dispatch<SetStateAction<Pages['Graphs']>>
 }) {
+  // Get IDs
   const graphIds = useAppSelector((state) => state.user.savedGraphs)
+  const degreeIds = useAppSelector((state) => state.user.savedDegrees)
   const hasGraphs = graphIds.length !== 0
+
+  // Load full degrees
+  const [degrees, setDegrees] = useState<ModtreeApiResponse.Degree[]>([])
+  useEffect(() => {
+    trpc.query('degrees', degreeIds).then((degrees) => {
+      setDegrees(degrees)
+    })
+  }, [degreeIds])
+
+  // Load graphs
   const [graphs, setGraphs] = useState<ModtreeApiResponse.Graph[]>([])
-
-  const degrees = useAppSelector((state) => state.user.savedDegrees)
-
   // placeholder state
   // updated correctly in useEffect
   const mainGraph = useAppSelector((state) => state.graph)
@@ -75,7 +84,7 @@ export function Main(props: {
 }
 
 function GraphSection(props: {
-  degrees: IDegree[]
+  degrees: ModtreeApiResponse.Degree[]
   graphs: ModtreeApiResponse.Graph[]
   mainGraph: ModtreeApiResponse.Graph
 }) {

--- a/apps/web/components/user-profile/graphs/main.tsx
+++ b/apps/web/components/user-profile/graphs/main.tsx
@@ -22,6 +22,9 @@ export function Main(props: {
   const degreeIds = useAppSelector((state) => state.user.savedDegrees)
   const hasGraphs = graphIds.length !== 0
 
+  const { user } = useUser()
+  const userId = user?.modtreeId
+
   // Load full degrees
   const [degrees, setDegrees] = useState<ModtreeApiResponse.Degree[]>([])
   useEffect(() => {
@@ -62,13 +65,14 @@ export function Main(props: {
         addButtonText={hasGraphs ? 'New graph' : ''}
         onAddClick={() => props.setPage('add-new')}
       >
-        {hasGraphs ? (
+        {hasGraphs && userId ? (
           <>
             <p>{text.graphListSection.summary}</p>
             <GraphSection
               degrees={degrees}
               graphs={graphs}
               mainGraph={mainGraph}
+              userId={userId}
             />
           </>
         ) : (
@@ -87,21 +91,17 @@ function GraphSection(props: {
   degrees: ModtreeApiResponse.Degree[]
   graphs: ModtreeApiResponse.Graph[]
   mainGraph: ModtreeApiResponse.Graph
+  userId: string
 }) {
   const { degrees, graphs } = props
 
-  const { user } = useUser()
-
   async function removeGraph(graphId: string) {
-    const userId = user?.modtreeId
-    if (userId) {
-      trpc
-        .mutation('user/remove-graph', {
-          userId,
-          graphId,
-        })
-        .then(() => updateUser())
-    }
+    trpc
+      .mutation('user/remove-graph', {
+        userId: props.userId,
+        graphId,
+      })
+      .then(() => updateUser())
   }
 
   return (

--- a/apps/web/components/user-profile/modules/main.tsx
+++ b/apps/web/components/user-profile/modules/main.tsx
@@ -7,28 +7,18 @@ import { Row } from '@/ui/settings/lists/rows'
 import { useAppDispatch, useAppSelector } from '@/store/redux'
 import { setBuildList } from '@/store/search'
 import { useEffect } from 'react'
-import { trpc } from '@/utils/trpc'
-import { addModulesToCache } from '@/store/cache'
+import { api } from 'api'
 
 export function Main(props: { setPage: SetState<Pages['Modules']> }) {
   const dispatch = useAppDispatch()
   const user = useAppSelector((state) => state.user)
   const cache = useAppSelector((state) => state.cache)
 
-  const updateCache = (codes: string[]) => {
-    const existingCodes = Object.keys(cache.modules)
-    const codesToFetch = codes.filter((c) => !existingCodes.includes(c))
-    if (codesToFetch.length === 0) return
-    return trpc
-      .query('modules', codesToFetch)
-      .then((modules) => dispatch(addModulesToCache(modules)))
-  }
-
   /**
    * update the cache with required modules
    */
   useEffect(() => {
-    updateCache([...user.modulesDone, ...user.modulesDoing])
+    api.module.loadCodes([...user.modulesDone, ...user.modulesDoing])
   }, [user.modulesDone, user.modulesDoing])
 
   const hasModules = {

--- a/apps/web/store/degree.ts
+++ b/apps/web/store/degree.ts
@@ -1,4 +1,4 @@
-import { IDegree } from '@modtree/types'
+import { ModtreeApiResponse } from '@modtree/types'
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { baseInitialState } from './initial-state'
 
@@ -6,7 +6,7 @@ export const degree = createSlice({
   name: 'degree',
   initialState: baseInitialState.degree,
   reducers: {
-    setDegree: (degree, action: PayloadAction<IDegree>) => {
+    setDegree: (degree, action: PayloadAction<ModtreeApiResponse.Degree>) => {
       Object.entries(action.payload).forEach(([key, value]) => {
         ;(degree as any)[key] = value
       })

--- a/apps/web/store/initial-state.ts
+++ b/apps/web/store/initial-state.ts
@@ -2,7 +2,7 @@ import type { ReduxState } from './types'
 import { empty } from '@modtree/utils'
 
 export const baseInitialState: ReduxState = {
-  user: empty.UserFull,
+  user: empty.User,
   degree: empty.Degree,
   graph: {
     ...empty.Graph,

--- a/apps/web/store/types.d.ts
+++ b/apps/web/store/types.d.ts
@@ -8,7 +8,7 @@ import {
 import type { Pages, ContextMenuProps } from 'types'
 
 export type ReduxState = {
-  user: ModtreeApiResponse.UserFull
+  user: ModtreeApiResponse.User
   degree: ModtreeApiResponse.Degree
   graph: ModtreeApiResponse.Graph & {
     selectedCodes: string[]

--- a/apps/web/store/user.ts
+++ b/apps/web/store/user.ts
@@ -12,7 +12,7 @@ export const user = createSlice({
     updateModulesDoing: (user, action: PayloadAction<string[]>) => {
       user.modulesDoing = action.payload
     },
-    setUser: (user, action: PayloadAction<ModtreeApiResponse.UserFull>) => {
+    setUser: (user, action: PayloadAction<ModtreeApiResponse.User>) => {
       Object.entries(action.payload).forEach(([key, value]) => {
         ;(user as any)[key] = value
       })

--- a/apps/web/ui/search/degree/degree-picker.tsx
+++ b/apps/web/ui/search/degree/degree-picker.tsx
@@ -1,13 +1,13 @@
 import { Listbox } from '@headlessui/react'
-import { IDegree, UseState } from '@modtree/types'
+import { ModtreeApiResponse, UseState } from '@modtree/types'
 import { CheckIcon, SelectorIcon } from '@/ui/icons'
 import { flatten } from '@/utils/tailwind'
 import { useEffect } from 'react'
 import { api } from 'api'
 
 export function DegreePicker(props: {
-  degrees: IDegree[]
-  select: UseState<IDegree>
+  degrees: ModtreeApiResponse.Degree[]
+  select: UseState<ModtreeApiResponse.Degree>
 }) {
   const [degree, setDegree] = props.select
 

--- a/apps/web/ui/search/degree/degree-picker.tsx
+++ b/apps/web/ui/search/degree/degree-picker.tsx
@@ -4,16 +4,12 @@ import { CheckIcon, SelectorIcon } from '@/ui/icons'
 import { flatten } from '@/utils/tailwind'
 import { useEffect } from 'react'
 import { api } from 'api'
-import { useAppSelector } from '@/store/redux'
 
 export function DegreePicker(props: {
   degrees: IDegree[]
   select: UseState<IDegree>
-  modulesDoneCodes: string[]
-  modulesDoingCodes: string[]
 }) {
   const [degree, setDegree] = props.select
-  const { buildList } = useAppSelector((state) => state.search)
 
   useEffect(() => {
     api.degree.setBuildTarget(degree.id)
@@ -50,12 +46,6 @@ export function DegreePicker(props: {
             ))}
           </Listbox.Options>
         </Listbox>
-      </div>
-      <div className="bg-gray-200 p-2 rounded-xl">
-        <p>
-          The following remaining degree modules will be placed in the graph:
-        </p>
-        <p className="mb-0">{buildList.join(', ')}</p>
       </div>
     </div>
   )

--- a/apps/web/ui/search/graph/graph-picker.tsx
+++ b/apps/web/ui/search/graph/graph-picker.tsx
@@ -24,7 +24,7 @@ export function GraphPicker(props: {
       api.user.setMainGraph(userId, graph.id)
       dispatch(setMainGraph(graph))
     }
-  }, [graph])
+  }, [graph.id])
 
   return (
     <div className={flatten('ui-rectangle', 'shadow-none', 'h-8 w-64')}>

--- a/apps/web/utils/rehydrate.ts
+++ b/apps/web/utils/rehydrate.ts
@@ -62,7 +62,7 @@ export function rehydrate(user: ModtreeUserProfile) {
  */
 export async function updateUser() {
   const userId = store.getState().user.id
-  return trpc.query('user/get-full', userId).then((user) => {
+  return trpc.query('user', userId).then((user) => {
     dispatch(setUser(user))
     return user
   })

--- a/apps/web/utils/rehydrate.ts
+++ b/apps/web/utils/rehydrate.ts
@@ -12,23 +12,23 @@ const dispatch = store.dispatch
 
 async function getUser(
   user: ModtreeUserProfile
-): Promise<ModtreeApiResponse.UserFull> {
-  const authZeroLoaded = user.modtreeId !== ''
-  const reduxLoaded = redux.user.id !== ''
+): Promise<ModtreeApiResponse.User> {
+  const authZeroLoaded = user.modtreeId && user.modtreeId !== ''
+  const reduxLoaded = redux.user.id && redux.user.id !== ''
   if (reduxLoaded) {
     return redux.user
   } else if (authZeroLoaded) {
     const userId = user?.modtreeId
-    if (!userId) return empty.UserFull
+    if (!userId) return empty.User
     return trpc
-      .query('user/get-full', userId)
+      .query('user', userId)
       .then((user) => {
         dispatch(setUser(user))
         return user
       })
-      .catch(() => empty.UserFull)
+      .catch(() => empty.User)
   } else {
-    return empty.UserFull
+    return empty.User
   }
 }
 
@@ -40,9 +40,11 @@ export function rehydrate(user: ModtreeUserProfile) {
   userPromise
     .then((user) => {
       if (redux.degree.id === '') {
-        const degree = user.mainDegree
-        if (!degree) return
-        dispatch(setDegree(degree))
+        const degreeId = user.mainDegree
+        if (!degreeId) return
+        trpc.query('degree', degreeId).then((d) => {
+          dispatch(setDegree(d))
+        })
       }
       if (redux.graph.id === '') {
         const graphId = user.mainGraph

--- a/libs/types/src/api-response.ts
+++ b/libs/types/src/api-response.ts
@@ -18,19 +18,6 @@ export type User = Modify<
 >
 
 /**
- * User API respsonse
- */
-export type UserFull = Modify<
-  IUser,
-  {
-    modulesDone: string[]
-    modulesDoing: string[]
-    savedGraphs: string[]
-    mainGraph: string
-  }
->
-
-/**
  * Degree API respsonse
  */
 export type Degree = Modify<

--- a/libs/utils/src/empty-entity.ts
+++ b/libs/utils/src/empty-entity.ts
@@ -1,5 +1,4 @@
 import {
-  IUser,
   IModule,
   IModuleCondensed,
   IModuleFull,
@@ -29,7 +28,7 @@ const DegreeFull: ModtreeApiResponse.DegreeFull = {
   title: '',
 }
 
-const User: IUser = {
+const User: ModtreeApiResponse.User = {
   id: '',
   authZeroId: '',
   displayName: '',
@@ -42,6 +41,8 @@ const User: IUser = {
   email: '',
   savedDegrees: [],
   savedGraphs: [],
+  mainGraph: '',
+  mainDegree: '',
 }
 
 const UserFull: ModtreeApiResponse.UserFull = {

--- a/libs/utils/src/empty-entity.ts
+++ b/libs/utils/src/empty-entity.ts
@@ -45,22 +45,6 @@ const User: ModtreeApiResponse.User = {
   mainDegree: '',
 }
 
-const UserFull: ModtreeApiResponse.UserFull = {
-  id: '',
-  authZeroId: '',
-  displayName: '',
-  username: '',
-  modulesDone: [],
-  modulesDoing: [],
-  matriculationYear: 0,
-  graduationYear: 0,
-  graduationSemester: 0,
-  email: '',
-  savedDegrees: [],
-  savedGraphs: [],
-  mainGraph: '',
-}
-
 const Graph: ModtreeApiResponse.Graph = {
   title: '',
   id: '',
@@ -104,7 +88,6 @@ export const empty = {
   ModuleFull,
   ModuleCondensed,
   User,
-  UserFull,
   Graph,
   Degree,
   DegreeFull,

--- a/libs/utils/src/entity/index.ts
+++ b/libs/utils/src/entity/index.ts
@@ -38,23 +38,6 @@ export const flatten = {
   },
 
   /**
-   * flattens a user to response shape
-   *
-   * @param {User} user
-   * @returns {ModtreeApiResponse.User}
-   */
-  userFull(user: User): ModtreeApiResponse.UserFull {
-    return {
-      ...user,
-      modulesDoing: user.modulesDoing.map(flatten.module),
-      modulesDone: user.modulesDone.map(flatten.module),
-      savedGraphs: user.savedGraphs.map((g) => g.id),
-      // in case no graph yet
-      mainGraph: user.mainGraph ? user.mainGraph.id : '',
-    }
-  },
-
-  /**
    * flattens a graph to response shape
    *
    * @param {Graph} graph


### PR DESCRIPTION
### Summary of changes

- Add graph panel only shows title and degree
- Frontend user state uses flattened degrees (i.e. we are back to the original `ModtreeApiResponse.User`)
- Retire `ModtreeApiResponse.UserFull`

### Testing

- e2e tests
- Edit Degree panel displays title and modules correctly
- Add Graph panel displays degree title correctly
