### PR TITLE
fix: only show module modal once data is loaded

### DIFF
--- a/apps/web/api/module.ts
+++ b/apps/web/api/module.ts
@@ -78,10 +78,10 @@ export class ModuleApi extends BaseApi {
    * @param {string} moduleCode
    */
   async openModuleModal(moduleCode: string) {
-    this.dispatch(showModuleModal())
-    return this.directGetByCode(moduleCode).then((module) =>
+    return this.directGetByCode(moduleCode).then((module) => {
       this.dispatch(setModalModule(module))
-    )
+      this.dispatch(showModuleModal())
+    })
   }
 
   /**

--- a/apps/web/store/modal.ts
+++ b/apps/web/store/modal.ts
@@ -28,6 +28,7 @@ export const modal = createSlice({
     },
     hideModuleModal: (state) => {
       state.showModuleModal = false
+      state.modalModule = baseInitialState.modal.modalModule
     },
     showModuleModal: (state) => {
       state.showModuleModal = true


### PR DESCRIPTION
### Summary of changes

- and also reset it to original state once it's closed