### PR TITLE
test(e2e): use fake credentials for local testing

### DIFF
--- a/apps/web-e2e/cypress/fixtures/session.json
+++ b/apps/web-e2e/cypress/fixtures/session.json
@@ -1,8 +1,0 @@
-{
-  "user": {
-    "name": "test user",
-    "email": "test@user.com"
-  },
-  "expires": "3000-01-01T00:00:00.000Z",
-  "accessToken": "abcdefghijklmnopqrst"
-}

--- a/apps/web-e2e/cypress/integration/user-profile/degrees.cy.ts
+++ b/apps/web-e2e/cypress/integration/user-profile/degrees.cy.ts
@@ -152,10 +152,10 @@ describe('degrees panel', () => {
       .click()
 
     // Remove last module
-    modules.pop()
-    cy.getCy('degree-modules-list')
-      .children()
-      .last()
+    const lastModuleCode = modules.pop()
+    cy.contains(lastModuleCode)
+      .parent()
+      .parent()
       .find('[data-cy="delete-button"]')
       .click()
 

--- a/apps/web-e2e/cypress/support/commands.ts
+++ b/apps/web-e2e/cypress/support/commands.ts
@@ -17,7 +17,8 @@ declare global {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     interface Chainable {
       login(): void
-      login2(): void
+      loginCred(): void
+      loginSocial(): void
       loadModuleModal<E>(
         moduleCode: string,
         title: string
@@ -37,10 +38,19 @@ Cypress.Commands.add('getCy', (value: string) => {
   return cy.get(`[data-cy=${value}]`)
 })
 
+Cypress.Commands.add('login', () => {
+  const isLocal = Cypress.config('baseUrl').includes('localhost')
+  if (isLocal) {
+    cy.loginCred()
+  } else {
+    cy.loginSocial()
+  }
+})
+
 /**
  * Primary login method for local testing.
  */
-Cypress.Commands.add('login', () => {
+Cypress.Commands.add('loginCred', () => {
   cy.visit('/')
   cy.getCy('sign-in-button').click()
   cy.contains('Sign in with Credentials').click()
@@ -51,10 +61,8 @@ Cypress.Commands.add('login', () => {
 
 /**
  * Slower, unstable login. But can be used to test dev/prod envs.
- * Rename login2 to login, and rename the other login to something else
- * to use immediately.
  */
-Cypress.Commands.add('login2', () => {
+Cypress.Commands.add('loginSocial', () => {
   const username = Cypress.env('GITHUB_USER')
   const password = Cypress.env('GITHUB_PW')
   const COOKIE_NAME = Cypress.env('COOKIE_NAME')

--- a/apps/web-e2e/cypress/support/commands.ts
+++ b/apps/web-e2e/cypress/support/commands.ts
@@ -37,55 +37,12 @@ Cypress.Commands.add('getCy', (value: string) => {
 })
 
 Cypress.Commands.add('login', () => {
-  const username = Cypress.env('GITHUB_USER')
-  const password = Cypress.env('GITHUB_PW')
-  const COOKIE_NAME = Cypress.env('COOKIE_NAME')
-  const SECURE_COOKIE_NAME = Cypress.env('SECURE_COOKIE_NAME')
-
-  const BASE_URL = Cypress.config('baseUrl')
-  // Login page URL
-  const loginUrl = BASE_URL + '/api/auth/signin'
-  // The selector for Google on our login page
-  const loginSelector = `form[action="${BASE_URL}/api/auth/signin/github"]`
-
-  const socialLoginOptions = {
-    username,
-    password,
-    loginUrl,
-    headless: true,
-    logs: false,
-    isPopup: true,
-    loginSelector,
-    postLoginSelector: '#modtree-user-circle',
-  }
-
   cy.visit('/')
+  cy.getCy('sign-in-button').click()
+  cy.contains('Sign in with Credentials').click()
 
-  return cy
-    .task('GitHubSocialLogin', socialLoginOptions)
-    .then(({ cookies }) => {
-      cy.clearCookies()
-
-      const cookie = cookies
-        .filter(
-          (cookie) =>
-            cookie.name === COOKIE_NAME || cookie.name === SECURE_COOKIE_NAME
-        )
-        .pop()
-      if (cookie) {
-        cy.setCookie(cookie.name, cookie.value, {
-          domain: cookie.domain,
-          expiry: cookie.expires,
-          httpOnly: cookie.httpOnly,
-          path: cookie.path,
-          secure: cookie.secure,
-        })
-
-        Cypress.Cookies.defaults({
-          preserve: [COOKIE_NAME, SECURE_COOKIE_NAME],
-        })
-      }
-    })
+  // wait for login to complete
+  cy.getCy('modtree-user-circle')
 })
 
 Cypress.Commands.add('loadModuleModal', (moduleCode: string, title: string) => {

--- a/apps/web/components/buttons/floating-user-button.tsx
+++ b/apps/web/components/buttons/floating-user-button.tsx
@@ -20,6 +20,7 @@ const SignedOutRect = () => (
       'font-medium text-white hover:bg-opacity-30',
       'hover:no-underline'
     )}
+    data-cy="sign-in-button"
   >
     Sign in
   </button>


### PR DESCRIPTION
### Summary of changes

- Use fake credentials for local testing (`yarn e2e`)
- Switch to `cypress-social-login` for remote testing (`yarn e2e:dev`, `yarn e2e:prod`)
- In degree test, use more accurate way to extract module to remove

### Testing

Run E2E test on localhost. It should use the fake credentials, and be much faster
