### PR TITLE
fix: prevent clicking save graph/degree multiple times

### DIFF
--- a/apps/web/components/user-profile/degrees/add-new.tsx
+++ b/apps/web/components/user-profile/degrees/add-new.tsx
@@ -11,10 +11,12 @@ import { createAndSaveDegree } from '@/store/functions'
 
 export function AddNew(props: { setPage: SetState<Pages['Degrees']> }) {
   /** hooks */
+  const [disabled, setDisabled] = useState(false)
   const [title, setTitle] = useState('')
   const buildList = useAppSelector((state) => state.search.buildList)
 
   async function saveDegree() {
+    setDisabled(true)
     props.setPage('main')
     createAndSaveDegree(title, buildList)
   }
@@ -48,7 +50,7 @@ export function AddNew(props: { setPage: SetState<Pages['Degrees']> }) {
         />
       </SettingsSection>
       <div className="flex flex-row-reverse">
-        <Button color="green" onClick={saveDegree}>
+        <Button color="green" disabled={disabled} onClick={saveDegree}>
           Save degree
         </Button>
       </div>

--- a/apps/web/components/user-profile/graphs/add-new.tsx
+++ b/apps/web/components/user-profile/graphs/add-new.tsx
@@ -10,6 +10,7 @@ import { createAndSaveGraph } from '@/store/functions'
 
 export function AddNew(props: { setPage: SetState<Pages['Graphs']> }) {
   const { degree: mainDegree } = useAppSelector((s) => s.modtree)
+  const [disabled, setDisabled] = useState(false)
   const [title, setTitle] = useState('')
   const [degree, setDegree] = useState<ApiResponse.Degree>(mainDegree)
 
@@ -19,6 +20,7 @@ export function AddNew(props: { setPage: SetState<Pages['Graphs']> }) {
       alert('Graph title should not be empty')
       return
     }
+    setDisabled(true)
     createAndSaveGraph(title, degree.id)
     props.setPage('main')
   }
@@ -37,7 +39,7 @@ export function AddNew(props: { setPage: SetState<Pages['Graphs']> }) {
         <DegreePicker degreeState={[degree, setDegree]} />
       </SettingsSection>
       <div className="flex flex-row-reverse">
-        <Button color="green" onClick={saveGraph}>
+        <Button color="green" disabled={disabled} onClick={saveGraph}>
           Save graph
         </Button>
       </div>

--- a/apps/web/ui/buttons/text.tsx
+++ b/apps/web/ui/buttons/text.tsx
@@ -17,7 +17,12 @@ export const colorMap: Record<string, string> = {
 }
 
 export function Button(props: ButtonProps) {
-  const color = props.color || 'gray'
+  /* if not defined, then set to gray */
+  let color = props.color || 'gray'
+  /* if disabled, then overwrite any color */
+  if (props.disabled) {
+    color = 'gray'
+  }
   const { className, children, ...rest } = props
   return (
     <button className={cc(colorMap[color])} {...rest}>


### PR DESCRIPTION
### Summary of changes

- Fixes #362
- Button turns gray if disabled

### Testing

- Go to `degrees/add-new.tsx`
- Locate the save function, and comment out `props.setPage("main")`, to temporarily disable redirect to main.
- Try to create a new degree. It does not redirect back to main, and you can see the button being disabled immediately.
- Repeat for `graphs/add-new.tsx`
