### PR TITLE
feat: use node types to manage module state

### DIFF
--- a/apps/web-e2e/cypress/integration/graph/new-graph.cy.ts
+++ b/apps/web-e2e/cypress/integration/graph/new-graph.cy.ts
@@ -34,15 +34,11 @@ describe('add-and-remove', () => {
 
   it('Add CS1231 to graph', () => {
     cy.addGraphModule('CS1231', 'Discrete Structures')
-    // TODO: really start using node types for states so this isn't so clutch
-    cy.getCy('node-CS1231').should('have.css', 'color', 'rgb(75, 85, 99)')
+    cy.getCy('node-CS1231-planned').should('exist')
   })
 
-  it('Remove CS1231 from graph', () => {
+  it('Teardown', () => {
     cy.removeGraphModule('CS1231')
-  })
-
-  it('Remove created graph', () => {
     cy.removeGraph('test-graph')
     assertGraphCount(1)
   })

--- a/apps/web-e2e/cypress/support/commands.ts
+++ b/apps/web-e2e/cypress/support/commands.ts
@@ -46,7 +46,7 @@ declare global {
 }
 
 Cypress.Commands.add('getCy', (value: string) => {
-  return cy.get(`[data-cy=${value}]`)
+  return cy.get(`[data-cy*="${value}"]`)
 })
 
 Cypress.Commands.add(

--- a/apps/web/components/flow/module-node.tsx
+++ b/apps/web/components/flow/module-node.tsx
@@ -1,49 +1,50 @@
 import { cc } from '@/utils/tailwind'
 import { IModuleCondensed } from '@modtree/types'
 import { Handle, Position } from 'react-flow-renderer'
+import { ModuleNodeProps } from 'types'
 
-const Title = (props: { className: string; title: string }) => {
+const Title = (props: { className?: string; title: string }) => {
+  const { className, title } = props
   return (
     <div
       className={cc(
         'text-sm font-medium',
         'tracking-custom text-center',
         'leading-5 text-gray-500',
-        props.className
+        className
       )}
     >
-      {props.title}
+      {title}
     </div>
   )
 }
 
-const ModuleCode = (props: { className: string; moduleCode: string }) => {
+const ModuleCode = (props: { className?: string; moduleCode: string }) => {
+  const { className, moduleCode } = props
   return (
-    <div className={cc('text-2xl font-semibold text-center', props.className)}>
-      {props.moduleCode}
+    <div className={cc('text-2xl font-semibold text-center', className)}>
+      {moduleCode}
     </div>
   )
 }
 
-export function ModuleNode(props: {
-  data: IModuleCondensed & { className?: { moduleCode: string; title: string } }
-}) {
-  const { moduleCode, title } = props.data
-  // use blank strings as default classNames for tailwind
-  const className = Object.assign(
-    { moduleCode: '', title: '' },
-    props.data.className
-  )
+export function ModuleNode(props: ModuleNodeProps) {
+  const { moduleCode, title, className } = props.data
   return (
     <div
-      className="h-24 w-40 px-2 bg-white flex flex-col justify-center shadow-md rounded-md"
+      className={cc(
+        'h-24 w-40',
+        'px-2 bg-white',
+        'flex flex-col justify-center',
+        'shadow-md rounded-md'
+      )}
       data-cy={`node-${moduleCode}`}
     >
       <Handle type="target" position={Position.Left} />
       <Handle type="source" position={Position.Right} />
       <div className="h-min">
-        <ModuleCode className={className.moduleCode} moduleCode={moduleCode} />
-        <Title className={className.title} title={title} />
+        <ModuleCode className={className?.moduleCode} moduleCode={moduleCode} />
+        <Title className={className?.title} title={title} />
       </div>
     </div>
   )

--- a/apps/web/components/flow/module-node.tsx
+++ b/apps/web/components/flow/module-node.tsx
@@ -38,7 +38,7 @@ export function ModuleNode(props: ModuleNodeProps) {
         'flex flex-col justify-center',
         'shadow-md rounded-md'
       )}
-      data-cy={`node-${moduleCode}`}
+      data-cy={`node-${moduleCode}-${props.type}`}
     >
       <Handle type="target" position={Position.Left} />
       <Handle type="source" position={Position.Right} />

--- a/apps/web/components/flow/nodes.tsx
+++ b/apps/web/components/flow/nodes.tsx
@@ -18,23 +18,24 @@ const nodes: NodeDef[] = [
   { type: 'suggested', moduleCode: 'text-gray-400 opacity-50' },
 ]
 
-function coloredNode(className: {
-  title?: string
+function coloredNode(
+  type: FlowNodeState,
+  title?: string,
   moduleCode?: string
-}): ComponentType<NodeProps> {
-  return (props: ModuleNodeProps) => {
-    const final = { ...props, data: { ...props.data, className } }
+): ComponentType<NodeProps> {
+  const node = (props: ModuleNodeProps) => {
+    const data = { ...props.data, className: { title, moduleCode } }
+    const final = { ...props, data }
     return <ModuleNode {...final} />
   }
+  node.displayName = `node-${type}`
+  return node
 }
 
 export const moduleNodes = nodes.reduce(
   (acc, node) => ({
     ...acc,
-    [node.type]: coloredNode({
-      title: node.title,
-      moduleCode: node.moduleCode,
-    }),
+    [node.type]: coloredNode(node.type, node.title, node.moduleCode),
   }),
   {} as NodeTypes
 )

--- a/apps/web/components/flow/nodes.tsx
+++ b/apps/web/components/flow/nodes.tsx
@@ -1,0 +1,40 @@
+import { ModuleNode } from './module-node'
+import type { ModuleNodeProps } from 'types'
+import { FlowNodeState } from '@modtree/types'
+import { NodeProps, NodeTypes } from 'react-flow-renderer'
+import { ComponentType } from 'react'
+
+type NodeDef = {
+  type: FlowNodeState
+  moduleCode?: string
+  title?: string
+}
+
+const nodes: NodeDef[] = [
+  { type: 'done', moduleCode: 'text-emerald-500 opacity-80' },
+  { type: 'doing', moduleCode: 'text-black opacity-100' },
+  { type: 'cannotTake', moduleCode: 'text-red-400 opacity-100' },
+  { type: 'planned', moduleCode: 'text-gray-400 opacity-100' },
+  { type: 'suggested', moduleCode: 'text-gray-400 opacity-50' },
+]
+
+function coloredNode(className: {
+  title?: string
+  moduleCode?: string
+}): ComponentType<NodeProps> {
+  return (props: ModuleNodeProps) => {
+    const final = { ...props, data: { ...props.data, className } }
+    return <ModuleNode {...final} />
+  }
+}
+
+export const moduleNodes = nodes.reduce(
+  (acc, node) => ({
+    ...acc,
+    [node.type]: coloredNode({
+      title: node.title,
+      moduleCode: node.moduleCode,
+    }),
+  }),
+  {} as NodeTypes
+)

--- a/apps/web/components/flow/pane.tsx
+++ b/apps/web/components/flow/pane.tsx
@@ -1,15 +1,12 @@
-import { MouseEvent, useEffect, useMemo } from 'react'
+import { MouseEvent, useEffect } from 'react'
 import ReactFlow, { Node, Background, useReactFlow } from 'react-flow-renderer'
 import { useAppDispatch, useAppSelector, r } from '@/store/redux'
 import { onContextMenu } from '@/ui/menu/context-menu'
 import { FlowControls } from './controls'
-import { ModuleNode } from './module-node'
 import { GraphFlowNode } from '@modtree/types'
+import { moduleNodes } from './nodes'
 
 export default function ModtreeFlow() {
-  /** TODO: use node types to set state */
-  const nodeTypes = useMemo(() => ({ moduleNode: ModuleNode }), [])
-
   /** hooks */
   const reactFlow = useReactFlow()
   const dispatch = useAppDispatch()
@@ -38,7 +35,7 @@ export default function ModtreeFlow() {
     <ReactFlow
       nodes={flowNodes}
       edges={flowEdges}
-      nodeTypes={nodeTypes}
+      nodeTypes={moduleNodes}
       /** hooks */
       onNodesChange={(chg) => dispatch(r.applyNodeChanges(chg))}
       onNodeDragStop={onNodeDragStop}

--- a/apps/web/components/modals/debug.tsx
+++ b/apps/web/components/modals/debug.tsx
@@ -30,7 +30,7 @@ export function DebugModal() {
         <Content>
           {{
             ...redux.graph,
-            flowNodes: redux.graph.flowNodes.map((n) => n.id),
+            flowNodes: redux.graph.flowNodes.map((n) => [n.id, n.type]),
           }}
         </Content>
 

--- a/apps/web/components/modals/module-info/contents.tsx
+++ b/apps/web/components/modals/module-info/contents.tsx
@@ -20,7 +20,7 @@ export function ModuleDetails() {
     // 1. hide module modal
     dispatch(r.hideModuleModal())
     // 2. add module to graph
-    addModuleNode(nodify(module))
+    addModuleNode(nodify(module, 'planned'))
   }
 
   return (

--- a/apps/web/types/index.d.ts
+++ b/apps/web/types/index.d.ts
@@ -1,5 +1,10 @@
 import type { ButtonHTMLAttributes, ReactElement, ComponentProps } from 'react'
-import type { UseState, Modify, GraphFlowNode } from '@modtree/types'
+import type {
+  UseState,
+  Modify,
+  GraphFlowNode,
+  IModuleCondensed,
+} from '@modtree/types'
 
 /**
  * for frontend-specific types.
@@ -92,4 +97,10 @@ export type ContextMenuProps = {
   left: number
   menu: ContextMenuType
   flowNode?: GraphFlowNode
+}
+
+export type ModuleNodeProps = {
+  data: IModuleCondensed & {
+    className?: { moduleCode?: string; title?: string }
+  }
 }

--- a/apps/web/types/index.d.ts
+++ b/apps/web/types/index.d.ts
@@ -100,6 +100,7 @@ export type ContextMenuProps = {
 }
 
 export type ModuleNodeProps = {
+  type?: string
   data: IModuleCondensed & {
     className?: { moduleCode?: string; title?: string }
   }

--- a/apps/web/utils/module-state.ts
+++ b/apps/web/utils/module-state.ts
@@ -1,21 +1,8 @@
-import {
-  FlowNodeState as State,
-  GraphFlowNode,
-  CanTakeModule,
-} from '@modtree/types'
-
-const cssMap = {
-  [State.DONE]: { moduleCode: 'text-emerald-500 opacity-80' },
-  [State.DOING]: { moduleCode: 'text-black opacity-100' },
-  [State.PLAN_CANNOT_TAKE]: { moduleCode: 'text-red-400 opacity-100' },
-  [State.PLAN_CAN_TAKE]: { moduleCode: 'text-gray-400 opacity-100' },
-  [State.SUGGESTED]: { moduleCode: 'text-gray-400 opacity-50' },
-}
+import { GraphFlowNode, CanTakeModule, FlowNodeState } from '@modtree/types'
 
 /**
  * canTake tells you if you can take each module in the graph,
  * having taken the rest of the modules.
- *
  */
 export function getCSS(
   nodes: GraphFlowNode[],
@@ -23,18 +10,18 @@ export function getCSS(
   doing: string[],
   canTake: CanTakeModule[]
 ): GraphFlowNode[] {
-  const getState = (moduleCode: string): State => {
+  const getState = (moduleCode: string): FlowNodeState => {
     // done/doing
-    if (done.includes(moduleCode)) return State.DONE
-    if (doing.includes(moduleCode)) return State.DOING
+    if (done.includes(moduleCode)) return 'done'
+    if (doing.includes(moduleCode)) return 'doing'
     // planned
     return canTake.find((m) => m.moduleCode === moduleCode)?.canTake
-      ? State.PLAN_CAN_TAKE
-      : State.PLAN_CANNOT_TAKE
+      ? 'planned'
+      : 'cannotTake'
   }
 
   return nodes.map((node) => ({
     ...node,
-    data: { ...node.data, className: cssMap[getState(node.data.moduleCode)] },
+    type: getState(node.data.moduleCode),
   }))
 }

--- a/libs/repos/src/graph/get-modules.ts
+++ b/libs/repos/src/graph/get-modules.ts
@@ -41,7 +41,7 @@ function modulify(moduleCodeSet: Set<string>, cache: Module[]): Module[] {
  *
  * @param {User} user
  * @param {Degree} degree
- * @returns {Promise<[Module[], Module[]]>}
+ * @returns {Promise<Result>}
  */
 export async function getModules(user: User, degree: Degree): Promise<Result> {
   const moduleCache = loadModules(user, degree)

--- a/libs/repos/src/graph/get-nodes.ts
+++ b/libs/repos/src/graph/get-nodes.ts
@@ -1,17 +1,7 @@
 import { GraphFlowEdge, GraphFlowNode, Module } from '@modtree/types'
 export * from './get-edges'
 import dagre from 'dagre'
-
-const origin = { x: 0, y: 0 }
-
-export function nodify(module: Module): GraphFlowNode {
-  return {
-    id: module.moduleCode,
-    position: origin,
-    data: module,
-    type: 'moduleNode',
-  }
-}
+import { nodify } from '@modtree/utils'
 
 export function getFlowNodes(
   modules: Module[],
@@ -33,5 +23,5 @@ export function getFlowNodes(
   /** compute the layout */
   dagre.layout(g)
 
-  return modules.map(nodify)
+  return modules.map((m) => nodify(m, 'planned'))
 }

--- a/libs/repos/src/graph/repo.ts
+++ b/libs/repos/src/graph/repo.ts
@@ -50,14 +50,17 @@ export class GraphRepository extends BaseRepo<Graph> {
      *  get flow edges from relations
      */
     const flowEdges = modules.then(({ modulesPlaced }) =>
-      getFlowEdges(modulesPlaced.map(nodify))
+      getFlowEdges(modulesPlaced.map((m) => nodify(m, 'planned')))
     )
     /**
      *  get flow nodes from dagre
      */
     const flowNodes = Promise.all([flowEdges, modules]).then(
       ([edges, { modulesPlaced }]) =>
-        getFlowNodes(modulesPlaced.map(nodify), edges)
+        getFlowNodes(
+          modulesPlaced.map((m) => nodify(m, 'planned')),
+          edges
+        )
     )
 
     /**

--- a/libs/repos/src/graph/repo.ts
+++ b/libs/repos/src/graph/repo.ts
@@ -1,6 +1,6 @@
 import { DataSource } from 'typeorm'
 import { Module, Graph, CanTakeModule, ApiResponse } from '@modtree/types'
-import { flatten, getFlowEdges, getFlowNodes, nodify } from '@modtree/utils'
+import { flatten, nodify } from '@modtree/utils'
 import { BaseRepo } from '../base'
 import { ModuleRepository } from '../module'
 import { UserRepository } from '../user'
@@ -47,27 +47,17 @@ export class GraphRepository extends BaseRepo<Graph> {
       return getModules(user, degree)
     })
     /**
-     *  get flow edges from relations
-     */
-    const flowEdges = modules.then(({ modulesPlaced }) =>
-      getFlowEdges(modulesPlaced.map((m) => nodify(m, 'planned')))
-    )
-    /**
      *  get flow nodes from dagre
      */
-    const flowNodes = Promise.all([flowEdges, modules]).then(
-      ([edges, { modulesPlaced }]) =>
-        getFlowNodes(
-          modulesPlaced.map((m) => nodify(m, 'planned')),
-          edges
-        )
+    const flowNodes = modules.then(({ modulesPlaced }) =>
+      modulesPlaced.map((m) => nodify(m, 'planned'))
     )
 
     /**
      * save the newly created graph
      */
-    return Promise.all([user, degree, modules, flowEdges, flowNodes]).then(
-      ([user, degree, modules, flowEdges, flowNodes]) =>
+    return Promise.all([user, degree, modules, flowNodes]).then(
+      ([user, degree, modules, flowNodes]) =>
         this.save(
           this.create({
             title,
@@ -76,7 +66,7 @@ export class GraphRepository extends BaseRepo<Graph> {
             modulesPlaced: modules.modulesPlaced,
             modulesHidden: modules.modulesHidden,
             flowNodes,
-            flowEdges,
+            flowEdges: [],
           })
         )
     )

--- a/libs/types/src/flow.ts
+++ b/libs/types/src/flow.ts
@@ -13,13 +13,9 @@ export type FlowEdgeCondensed = {
   target: string
 }
 
-/**
- * For module styling
- */
-export enum FlowNodeState {
-  DONE = 'done',
-  DOING = 'doing',
-  PLAN_CAN_TAKE = 'plan can take',
-  PLAN_CANNOT_TAKE = 'plan cannot take',
-  SUGGESTED = 'suggested',
-}
+export type FlowNodeState =
+  | 'done'
+  | 'doing'
+  | 'planned'
+  | 'cannotTake'
+  | 'suggested'

--- a/libs/utils/src/flow/get-nodes.ts
+++ b/libs/utils/src/flow/get-nodes.ts
@@ -8,12 +8,12 @@ import dagre from 'dagre'
 
 const origin = { x: 0, y: 0 }
 
-export function nodify(module: IModule): GraphFlowNode {
+export function nodify(module: IModule, type: FlowNodeState): GraphFlowNode {
   return {
     id: module.moduleCode,
     position: origin,
     data: module,
-    type: 'done' as FlowNodeState,
+    type,
   }
 }
 

--- a/libs/utils/src/flow/get-nodes.ts
+++ b/libs/utils/src/flow/get-nodes.ts
@@ -1,4 +1,9 @@
-import { GraphFlowEdge, GraphFlowNode, IModule } from '@modtree/types'
+import {
+  FlowNodeState,
+  GraphFlowEdge,
+  GraphFlowNode,
+  IModule,
+} from '@modtree/types'
 import dagre from 'dagre'
 
 const origin = { x: 0, y: 0 }
@@ -8,7 +13,7 @@ export function nodify(module: IModule): GraphFlowNode {
     id: module.moduleCode,
     position: origin,
     data: module,
-    type: 'moduleNode',
+    type: 'done' as FlowNodeState,
   }
 }
 


### PR DESCRIPTION
### Summary of changes

- use React Flow's `nodeType` to directly manage our core logic's module state
