### PR TITLE
feat: migrate base endpoint to `/trpc`

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -21,7 +21,7 @@ export function getApp(): Express {
   const app = express()
   app.use(cors(corsOpts))
   app.use(express.json())
-  app.use('/', createMid({ router: appRouter }))
+  app.use('/trpc', createMid({ router: appRouter }))
   /** register root route */
   app.get('/', (_req: Request, res: Response) => {
     res.status(200).send('modtree server is running')

--- a/apps/web/utils/trpc.ts
+++ b/apps/web/utils/trpc.ts
@@ -6,7 +6,7 @@ export const trpcReact = createReactQueryHooks<AppRouter>()
 
 const envUrl = process.env.NEXT_PUBLIC_BACKEND
 
-export const trpcClientUrl = envUrl ? envUrl : 'http://localhost:8080'
+export const trpcClientUrl = envUrl ? envUrl : 'http://localhost:8080/trpc'
 
 export const trpc = createTRPCClient<AppRouter>({
   url: trpcClientUrl,


### PR DESCRIPTION
### Summary of changes

- tRPC router is now mounted at `/trpc`.
- BREAKING: In `.env`, `NEXT_PUBLIC_BACKEND` should point to the new backend at `/trpc`. This includes the development and local deployments.

### Testing

E2E tests pass locally
