### PR TITLE
test(e2e): add wait-less redux state getters

### DIFF
--- a/apps/web-e2e/cypress.config.js
+++ b/apps/web-e2e/cypress.config.js
@@ -9,7 +9,6 @@ module.exports = defineConfig({
   screenshotsFolder: '../../dist/cypress/apps/web-e2e/screenshots',
   chromeWebSecurity: false,
   e2e: {
-    //setupNodeEvents(on, config) {},
     specPattern: './cypress/integration/**/*.cy.{js,jsx,ts,tsx}',
     supportFile: './cypress/support/index.ts',
     baseUrl: 'http://localhost:3000',

--- a/apps/web-e2e/cypress/integration/cypress-utils/redux.cy.ts
+++ b/apps/web-e2e/cypress/integration/cypress-utils/redux.cy.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod'
+
+/** for local use only */
+const uuid = z.string().uuid()
+
+/**
+ * checks that the entity passed in has an id property
+ * that is a valid UUID
+ */
+const checkId = (entity: any) => {
+  const id = uuid.safeParse(entity.id)
+  expect(id).to.have.nested.include({ success: true })
+}
+
+/**
+ * check that the entity passed in has all the properties listed
+ */
+const checkProps = (entity: any, props: string[]) => {
+  props.forEach((p) => expect(entity).to.have.property(p))
+}
+
+describe('redux', () => {
+  before(() => cy.login())
+
+  it('graph state', () => {
+    cy.reduxGraph().then((graph) => {
+      checkId(graph)
+      checkProps(graph, ['flowNodes', 'flowEdges'])
+    })
+  })
+
+  it('user state', () => {
+    cy.reduxUser().then((user) => {
+      checkId(user)
+      checkProps(user, ['email', 'username', 'mainGraph', 'mainDegree'])
+    })
+  })
+
+  it('degree state', () => {
+    cy.reduxDegree().then((degree) => {
+      checkId(degree)
+      checkProps(degree, ['title', 'modules'])
+    })
+  })
+})

--- a/apps/web-e2e/cypress/integration/graph/add-and-remove.cy.ts
+++ b/apps/web-e2e/cypress/integration/graph/add-and-remove.cy.ts
@@ -2,23 +2,13 @@ describe('add-and-remove', () => {
   const code = 'MA2104'
   const title = 'Multivariable Calculus'
 
-  beforeEach(() => {
-    cy.login()
-    cy.reload()
-  })
+  beforeEach(() => cy.login())
 
   it('Graph does not contain MA2104', () => {
-    // getUser has completed
-    // Wait for store to load
-    cy.wait(2000)
-    cy.window()
-      .its('store')
-      .invoke('getState')
-      .its('graph.flowNodes')
-      .then((nodes) => {
-        const moduleCodes = nodes.map((n) => n.id)
-        expect(moduleCodes).to.not.contain('MA2104')
-      })
+    cy.reduxGraph().then((graph) => {
+      const moduleCodes = graph.flowNodes.map((n) => n.id)
+      expect(moduleCodes).to.not.contain(code)
+    })
   })
 
   it('adds a module', () => {
@@ -27,7 +17,7 @@ describe('add-and-remove', () => {
   })
 
   it('cannot add the same module', () => {
-    cy.loadModuleModal(code, title).then(() => {
+    cy.openModuleModal(code, title).then(() => {
       // Should not have add to graph button
       cy.getCy('module-modal').contains('Add to graph').should('not.exist')
 
@@ -42,7 +32,7 @@ describe('add-and-remove', () => {
   })
 
   it('can now add the same module', () => {
-    cy.loadModuleModal(code, title).then(() => {
+    cy.openModuleModal(code, title).then(() => {
       // Should have add to graph button
       cy.getCy('module-modal').contains('Add to graph').should('be.visible')
 

--- a/apps/web-e2e/cypress/integration/user-profile/degrees.cy.ts
+++ b/apps/web-e2e/cypress/integration/user-profile/degrees.cy.ts
@@ -44,6 +44,7 @@ function checkDegreeCount() {
 function checkModules() {
   const arr = []
   cy.getCy('degree-module')
+    .filter('span')
     .each((span) => {
       arr.push(span.text())
     })

--- a/apps/web-e2e/cypress/support/app.po.ts
+++ b/apps/web-e2e/cypress/support/app.po.ts
@@ -1,1 +1,0 @@
-export const getGreeting = () => cy.get('h1')

--- a/apps/web-e2e/cypress/support/commands.ts
+++ b/apps/web-e2e/cypress/support/commands.ts
@@ -16,10 +16,11 @@ declare global {
   namespace Cypress {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     interface Chainable {
-      login(): void
-      loginCred(): void
-      loginSocial(): void
-      loadModuleModal<E>(
+      /** general utilities */
+      getCy<E>(value: string): Chainable<JQuery<E>>
+
+      /** module */
+      openModuleModal<E>(
         moduleCode: string,
         title: string
       ): Chainable<JQuery<E>>
@@ -35,29 +36,33 @@ declare global {
       /** basic graph operations */
       addGraph<E>(title: string): Chainable<JQuery<E>>
       removeGraph<E>(title: string): Chainable<JQuery<E>>
-
-      /*
-       * The return type for this is the same as cy.get().
-       * This is a wrapper for cy.get().
-       */
-      getCy<E>(value: string): Chainable<JQuery<E>>
     }
   }
 }
 
-Cypress.Commands.add('getCy', (value: string) => {
-  return cy.get(`[data-cy*="${value}"]`)
-})
+/**
+ * The return type for this is the same as cy.get().
+ * This is a wrapper for cy.get().
+ */
+Cypress.Commands.add('getCy', (s: string) => cy.get(`[data-cy*="${s}"]`))
 
+/**
+ * opens user profile to the specified page
+ *
+ * @param {'Degrees' | 'Graphs' | 'Modules'} page
+ */
 Cypress.Commands.add(
   'openUserProfile',
-  (value: 'Degrees' | 'Graphs' | 'Modules') => {
+  (page: 'Degrees' | 'Graphs' | 'Modules') => {
     cy.getCy('modtree-user-circle').click()
     cy.contains('Your profile').click()
-    return cy.contains(value).click()
+    return cy.contains(page).click()
   }
 )
 
+/**
+ * adds a graph to the user's list of saved graphs
+ */
 Cypress.Commands.add('addGraph', (title: string) => {
   cy.openUserProfile('Graphs')
   cy.get('button').contains('New graph').click()
@@ -66,6 +71,9 @@ Cypress.Commands.add('addGraph', (title: string) => {
   return cy.closeUserProfile()
 })
 
+/**
+ * removes a graph from the user's list of saved graphs
+ */
 Cypress.Commands.add('removeGraph', (title: string) => {
   cy.openUserProfile('Graphs')
   cy.get('div')
@@ -75,100 +83,33 @@ Cypress.Commands.add('removeGraph', (title: string) => {
   return cy.closeUserProfile()
 })
 
+/**
+ * closes the user profile modal
+ */
 Cypress.Commands.add('closeUserProfile', () => {
   return cy.get('body').click(0, 0)
 })
 
-Cypress.Commands.add('login', () => {
-  const isLocal = Cypress.config('baseUrl').includes('localhost')
-  if (isLocal) {
-    cy.loginCred()
-  } else {
-    cy.loginSocial()
-  }
-})
-
 /**
- * Primary login method for local testing.
+ * opens the module modal to a particular module
+ *
+ * @param {string} moduleCode
+ * @param {string} title
  */
-Cypress.Commands.add('loginCred', () => {
-  cy.visit('/')
-  cy.getCy('sign-in-button').click()
-  cy.contains('Sign in with Credentials').click()
-
-  // wait for login to complete
-  cy.getCy('modtree-user-circle')
-})
-
-/**
- * Slower, unstable login. But can be used to test dev/prod envs.
- */
-Cypress.Commands.add('loginSocial', () => {
-  const username = Cypress.env('GITHUB_USER')
-  const password = Cypress.env('GITHUB_PW')
-  const COOKIE_NAME = Cypress.env('COOKIE_NAME')
-  const SECURE_COOKIE_NAME = Cypress.env('SECURE_COOKIE_NAME')
-
-  const BASE_URL = Cypress.config('baseUrl')
-  // Login page URL
-  const loginUrl = BASE_URL + '/api/auth/signin'
-  // The selector for Google on our login page
-  const loginSelector = `form[action="${BASE_URL}/api/auth/signin/github"]`
-
-  const socialLoginOptions = {
-    username,
-    password,
-    loginUrl,
-    headless: true,
-    logs: false,
-    isPopup: true,
-    loginSelector,
-    postLoginSelector: '#modtree-user-circle',
-  }
-
-  cy.visit('/')
-
-  return cy
-    .task('GitHubSocialLogin', socialLoginOptions)
-    .then(({ cookies }) => {
-      cy.clearCookies()
-
-      const cookie = cookies
-        .filter(
-          (cookie) =>
-            cookie.name === COOKIE_NAME || cookie.name === SECURE_COOKIE_NAME
-        )
-        .pop()
-      if (cookie) {
-        cy.setCookie(cookie.name, cookie.value, {
-          domain: cookie.domain,
-          expiry: cookie.expires,
-          httpOnly: cookie.httpOnly,
-          path: cookie.path,
-          secure: cookie.secure,
-        })
-
-        Cypress.Cookies.defaults({
-          preserve: [COOKIE_NAME, SECURE_COOKIE_NAME],
-        })
-      }
-    })
-})
-
-Cypress.Commands.add('loadModuleModal', (moduleCode: string, title: string) => {
-  return cy
-    .getCy('root-search-box')
+Cypress.Commands.add('openModuleModal', (moduleCode: string, title: string) => {
+  cy.getCy('root-search-box')
     .clear()
     .type(moduleCode)
-    .then(() => {
-      cy.getCy('search-result').contains(title).click()
-      // wait for modal to load
-      cy.get('h1').contains(moduleCode)
-    })
+    .getCy('search-result')
+    .contains(title)
+    .click()
+    // wait for modal to load
+    .get('h1')
+    .contains(moduleCode)
 })
 
 Cypress.Commands.add('addGraphModule', (moduleCode: string, title: string) => {
-  cy.loadModuleModal(moduleCode, title).then(() => {
+  cy.openModuleModal(moduleCode, title).then(() => {
     cy.get('button').contains('Add to graph').click()
     cy.getCy(`node-${moduleCode}`)
   })
@@ -186,7 +127,6 @@ Cypress.Commands.add('removeGraphModule', (moduleCode: string) => {
     })
 })
 
-//
 // -- This is a parent command --
 //Cypress.Commands.add('login', (email, password) => {
 // console.debug('Custom command example: Login', email, password)

--- a/apps/web-e2e/cypress/support/index.ts
+++ b/apps/web-e2e/cypress/support/index.ts
@@ -15,3 +15,5 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
+import './login'
+import './redux'

--- a/apps/web-e2e/cypress/support/login.ts
+++ b/apps/web-e2e/cypress/support/login.ts
@@ -1,0 +1,91 @@
+// Indicate that this file is a module
+export {}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+declare global {
+  namespace Cypress {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    interface Chainable {
+      login(): void
+      loginCred(): void
+      loginSocial(): void
+    }
+  }
+}
+
+/**
+ * logs the user in.
+ * meant to be used in the before() call
+ */
+Cypress.Commands.add('login', () => {
+  const isLocal = Cypress.config('baseUrl').includes('localhost')
+  if (isLocal) {
+    cy.loginCred()
+  } else {
+    cy.loginSocial()
+  }
+})
+
+/**
+ * Primary login method for local testing.
+ */
+Cypress.Commands.add('loginCred', () => {
+  // on the home page, click on the sign in button
+  cy.visit('/')
+  cy.getCy('sign-in-button').click()
+
+  // click on the password-less test user sign in
+  cy.contains('Sign in with Credentials').click()
+
+  // wait for login to complete
+  cy.getCy('modtree-user-circle')
+})
+
+/**
+ * Slower, unstable login. But can be used to test dev/prod envs.
+ */
+Cypress.Commands.add('loginSocial', () => {
+  const username = Cypress.env('GITHUB_USER')
+  const password = Cypress.env('GITHUB_PW')
+  const COOKIE_NAME = Cypress.env('COOKIE_NAME')
+  const SECURE_COOKIE_NAME = Cypress.env('SECURE_COOKIE_NAME')
+  const BASE_URL = Cypress.config('baseUrl')
+  // Login page URL
+  const loginUrl = BASE_URL + '/api/auth/signin'
+  // The selector for Google on our login page
+  const loginSelector = `form[action="${BASE_URL}/api/auth/signin/github"]`
+  const socialLoginOptions = {
+    username,
+    password,
+    loginUrl,
+    headless: true,
+    logs: false,
+    isPopup: true,
+    loginSelector,
+    postLoginSelector: '#modtree-user-circle',
+  }
+  cy.visit('/')
+  return cy
+    .task('GitHubSocialLogin', socialLoginOptions)
+    .then(({ cookies }) => {
+      cy.clearCookies()
+      const cookie = cookies
+        .filter(
+          (cookie) =>
+            cookie.name === COOKIE_NAME || cookie.name === SECURE_COOKIE_NAME
+        )
+        .pop()
+      if (cookie) {
+        cy.setCookie(cookie.name, cookie.value, {
+          domain: cookie.domain,
+          expiry: cookie.expires,
+          httpOnly: cookie.httpOnly,
+          path: cookie.path,
+          secure: cookie.secure,
+        })
+        Cypress.Cookies.defaults({
+          preserve: [COOKIE_NAME, SECURE_COOKIE_NAME],
+        })
+      }
+    })
+})

--- a/apps/web-e2e/cypress/support/redux.ts
+++ b/apps/web-e2e/cypress/support/redux.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod'
+import type { ReduxState } from '../../../web/store/types'
+
+// Indicate that this file is a module
+export {}
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+declare global {
+  namespace Cypress {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    interface Chainable {
+      reduxGraph(): Chainable<ReduxState['graph']>
+      reduxDegree(): Chainable<ReduxState['modtree']['degree']>
+      reduxUser(): Chainable<ReduxState['modtree']['user']>
+    }
+  }
+}
+
+/** for use in this file only */
+const getState = () => cy.window().its('store').invoke('getState')
+
+/**
+ * waits for the redux graph state to load, then returns it
+ */
+Cypress.Commands.add('reduxGraph', () => {
+  return getState()
+    .should((state) => {
+      /** wait for graph id to become a valid uuid */
+      const parsed = z.string().uuid().safeParse(state.graph.id)
+      expect(parsed).to.have.nested.include({ success: true })
+    })
+    .its('graph')
+})
+
+/**
+ * waits for the redux user state to load, then returns it
+ */
+Cypress.Commands.add('reduxUser', () => {
+  return getState()
+    .should((state) => {
+      /** wait for graph id to become a valid uuid */
+      const parsed = z.string().uuid().safeParse(state.modtree.user.id)
+      expect(parsed).to.have.nested.include({ success: true })
+    })
+    .its('modtree.user')
+})
+
+/**
+ * waits for the redux degree state to load, then returns it
+ */
+Cypress.Commands.add('reduxDegree', () => {
+  return getState()
+    .should((state) => {
+      /** wait for graph id to become a valid uuid */
+      const parsed = z.string().uuid().safeParse(state.modtree.degree.id)
+      expect(parsed).to.have.nested.include({ success: true })
+    })
+    .its('modtree.degree')
+})


### PR DESCRIPTION
### Summary of changes

* packaged up redux state-getting in cypress tests
  * to get graph state, for example:
  ```typescript
  cy.reduxGraph().then((graph) => {
    // do graph stuff here
  }
  ```
* `cy.reduxUser()` and `cy.reduxDegree()` are also available
* add tests to make sure these state getters work