### PR TITLE
feat: also support OpenAPI routes

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -2,6 +2,7 @@ import cors from 'cors'
 import express, { Request, Response, Express } from 'express'
 import { createExpressMiddleware as createMid } from '@trpc/server/adapters/express'
 import { appRouter } from './trpc'
+import { createOpenApiExpressMiddleware } from 'trpc-openapi'
 
 const corsOpts = {
   origin: [
@@ -21,7 +22,10 @@ export function getApp(): Express {
   const app = express()
   app.use(cors(corsOpts))
   app.use(express.json())
+  /** for tRPC typesafe API calls */
   app.use('/trpc', createMid({ router: appRouter }))
+  /** for OpenAPI support */
+  app.use('/api', createOpenApiExpressMiddleware({ router: appRouter }))
   /** register root route */
   app.get('/', (_req: Request, res: Response) => {
     res.status(200).send('modtree server is running')

--- a/apps/server/src/schemas/entities.ts
+++ b/apps/server/src/schemas/entities.ts
@@ -1,5 +1,6 @@
 import { z, ZodType } from 'zod'
 import { validModuleRegex } from '@modtree/utils'
+import { NUSMods as NM } from '@modtree/types'
 
 /**
  * NUSMods types in zod
@@ -57,7 +58,7 @@ const NUSMods: ZodNUSMods = {
 /**
  * this zod type is declared on its own as it references itself
  */
-const prereqTree: ZodType = z.string().or(
+const prereqTree: ZodType<NM.PrereqTree> = z.string().or(
   z.lazy(() =>
     z.object({
       and: z.array(prereqTree).optional(),

--- a/apps/server/src/schemas/entities.ts
+++ b/apps/server/src/schemas/entities.ts
@@ -1,0 +1,156 @@
+import { z } from 'zod'
+import { validModuleRegex } from '@modtree/utils'
+
+/**
+ * NUSMods types in zod
+ */
+const NUSMods = {
+  Attributes: z
+    .object({
+      year: z.boolean(),
+      su: z.boolean(),
+      grsu: z.boolean(),
+      ssgf: z.boolean(),
+      sfs: z.boolean(),
+      lab: z.boolean(),
+      ism: z.boolean(),
+      urop: z.boolean(),
+      fyp: z.boolean(),
+      mpes1: z.boolean(),
+      mpes2: z.boolean(),
+    })
+    .partial(),
+  WeekRange: z.object({
+    start: z.string(),
+    end: z.string(),
+    weekInterval: z.number().optional(),
+    weeks: z.array(z.number()).optional(),
+  }),
+  SemesterData: z.object({
+    semester: z.number(),
+    timetable: z.array(
+      z.object({
+        classNo: z.string(),
+        day: z.string(),
+        endTime: z.string(),
+        lessonType: z.string(),
+        startTime: z.string(),
+        venue: z.string(),
+        weeks: z.array(z.number()).or(
+          /* lazy because it references NUSMods.WeekRange */
+          z.lazy(() => NUSMods.WeekRange)
+        ),
+        size: z.number(),
+      })
+    ),
+    examDate: z.string().optional(),
+    examDuration: z.number().optional(),
+  }),
+  PrereqTree: z.string().or(
+    z.lazy(() =>
+      z.object({
+        and: z.array(NUSMods.prereqTree).optional(),
+        or: z.array(NUSMods.prereqTree).optional(),
+      })
+    )
+  ),
+}
+
+const deleteResult = z.object({
+  raw: z.any(),
+  affected: z.number().or(z.null()).optional(),
+})
+
+const Module = z.object({
+  id: z.string().uuid(),
+  moduleCode: z.string().regex(validModuleRegex),
+  title: z.string(),
+  prerequisite: z.string(),
+  corequisite: z.string(),
+  preclusion: z.string(),
+  fulfillRequirements: z.array(z.string().regex(validModuleRegex)),
+  prereqTree: NUSMods.PrereqTree,
+})
+
+const entities = {
+  /** FLATTENED */
+  User: z.object({
+    id: z.string().uuid(),
+    facebookId: z.string(),
+    googleId: z.string(),
+    githubId: z.string(),
+    displayName: z.string(),
+    username: z.string(),
+    email: z.string().email(),
+    matriculationYear: z.number(),
+    graduationYear: z.number(),
+    graduationSemester: z.number(),
+    modulesDone: z.array(z.string().regex(validModuleRegex)),
+    modulesDoing: z.array(z.string().regex(validModuleRegex)),
+    savedDegrees: z.array(z.string().uuid()),
+    savedGraphs: z.array(z.string().uuid()),
+    /** allow empty string for CREATE endpoint */
+    mainDegree: z.string().uuid().or(z.string()),
+    mainGraph: z.string().uuid().or(z.string()),
+  }),
+  Module,
+  ModuleCondensed: z.object({
+    id: z.string().uuid(),
+    moduleCode: z.string().regex(validModuleRegex),
+    title: z.string(),
+  }),
+  ModuleFull: Module.extend({
+    acadYear: z.string(),
+    description: z.string(),
+    moduleCredit: z.string(),
+    department: z.string(),
+    faculty: z.string(),
+    aliases: z.array(z.string().regex(validModuleRegex)),
+    /* empty string */
+    attributes: z.string().or(NUSMods.Attributes),
+    /* empty string */
+    semesterData: z.array(NUSMods.SemesterData),
+    workload: z.string().or(z.array(z.number())),
+  }),
+  /** FLATTENED */
+  Degree: z.object({
+    id: z.string().uuid(),
+    title: z.string(),
+    modules: z.array(z.string().regex(validModuleRegex)),
+  }),
+  /** FLATTENED */
+  Graph: z.object({
+    id: z.string().uuid(),
+    title: z.string(),
+    user: z.string().uuid(),
+    degree: z.object({
+      id: z.string().uuid(),
+      title: z.string(),
+    }),
+    modulesPlaced: z.array(z.string().regex(validModuleRegex)),
+    modulesHidden: z.array(z.string().regex(validModuleRegex)),
+    /** irrelevant optional props are left out */
+    flowNodes: z.array(
+      z.object({
+        id: z.string(),
+        position: z.object({
+          x: z.number(),
+          y: z.number(),
+        }),
+        data: Module,
+        className: z.string().optional(),
+        selected: z.boolean().optional(),
+      })
+    ),
+    /** irrelevant optional props are left out */
+    flowEdges: z.array(
+      z.object({
+        id: z.string(),
+        source: z.string(),
+        target: z.string(),
+      })
+    ),
+  }),
+}
+
+export { deleteResult, entities }

--- a/apps/server/src/schemas/entities.ts
+++ b/apps/server/src/schemas/entities.ts
@@ -46,15 +46,16 @@ const NUSMods = {
     examDate: z.string().optional(),
     examDuration: z.number().optional(),
   }),
-  PrereqTree: z.string().or(
-    z.lazy(() =>
-      z.object({
-        and: z.array(NUSMods.prereqTree).optional(),
-        or: z.array(NUSMods.prereqTree).optional(),
-      })
-    )
-  ),
 }
+
+const prereqTree = z.string().or(
+  z.lazy(() =>
+    z.object({
+      and: z.array(prereqTree).optional(),
+      or: z.array(prereqTree).optional(),
+    })
+  )
+)
 
 const deleteResult = z.object({
   raw: z.any(),
@@ -69,7 +70,7 @@ const Module = z.object({
   corequisite: z.string(),
   preclusion: z.string(),
   fulfillRequirements: z.array(z.string().regex(validModuleRegex)),
-  prereqTree: NUSMods.PrereqTree,
+  prereqTree,
 })
 
 const entities = {

--- a/apps/server/src/schemas/entities.ts
+++ b/apps/server/src/schemas/entities.ts
@@ -6,9 +6,9 @@ import { NUSMods as NM } from '@modtree/types'
  * NUSMods types in zod
  */
 type ZodNUSMods = {
-  Attributes: ZodType
-  WeekRange: ZodType
-  SemesterData: ZodType
+  Attributes: ZodType<NM.NUSModuleAttributes>
+  WeekRange: ZodType<NM.WeekRange>
+  SemesterData: ZodType<NM.SemesterData>
 }
 
 const NUSMods: ZodNUSMods = {

--- a/apps/server/src/schemas/entities.ts
+++ b/apps/server/src/schemas/entities.ts
@@ -162,6 +162,7 @@ const entities = {
             y: z.number(),
           }),
           data: Module,
+          type: z.string().optional(),
           className: z.string().optional(),
           selected: z.boolean().optional(),
         })

--- a/apps/server/src/schemas/entities.ts
+++ b/apps/server/src/schemas/entities.ts
@@ -1,10 +1,16 @@
-import { z } from 'zod'
+import { z, ZodType } from 'zod'
 import { validModuleRegex } from '@modtree/utils'
 
 /**
  * NUSMods types in zod
  */
-const NUSMods = {
+type ZodNUSMods = {
+  Attributes: ZodType
+  WeekRange: ZodType
+  SemesterData: ZodType
+}
+
+const NUSMods: ZodNUSMods = {
   Attributes: z
     .object({
       year: z.boolean(),
@@ -48,7 +54,7 @@ const NUSMods = {
   }),
 }
 
-const prereqTree = z.string().or(
+const prereqTree: ZodType = z.string().or(
   z.lazy(() =>
     z.object({
       and: z.array(prereqTree).optional(),

--- a/apps/server/src/schemas/entities.ts
+++ b/apps/server/src/schemas/entities.ts
@@ -54,6 +54,9 @@ const NUSMods: ZodNUSMods = {
   }),
 }
 
+/**
+ * this zod type is declared on its own as it references itself
+ */
 const prereqTree: ZodType = z.string().or(
   z.lazy(() =>
     z.object({
@@ -68,44 +71,54 @@ const deleteResult = z.object({
   affected: z.number().or(z.null()).optional(),
 })
 
-const Module = z.object({
-  id: z.string().uuid(),
-  moduleCode: z.string().regex(validModuleRegex),
-  title: z.string(),
-  prerequisite: z.string(),
-  corequisite: z.string(),
-  preclusion: z.string(),
-  fulfillRequirements: z.array(z.string().regex(validModuleRegex)),
-  prereqTree,
-})
-
-const entities = {
-  /** FLATTENED */
-  User: z.object({
-    id: z.string().uuid(),
-    facebookId: z.string(),
-    googleId: z.string(),
-    githubId: z.string(),
-    displayName: z.string(),
-    username: z.string(),
-    email: z.string().email(),
-    matriculationYear: z.number(),
-    graduationYear: z.number(),
-    graduationSemester: z.number(),
-    modulesDone: z.array(z.string().regex(validModuleRegex)),
-    modulesDoing: z.array(z.string().regex(validModuleRegex)),
-    savedDegrees: z.array(z.string().uuid()),
-    savedGraphs: z.array(z.string().uuid()),
-    /** allow empty string for CREATE endpoint */
-    mainDegree: z.string().uuid().or(z.string()),
-    mainGraph: z.string().uuid().or(z.string()),
-  }),
-  Module,
-  ModuleCondensed: z.object({
+const Module = z
+  .object({
     id: z.string().uuid(),
     moduleCode: z.string().regex(validModuleRegex),
     title: z.string(),
-  }),
+    prerequisite: z.string(),
+    corequisite: z.string(),
+    preclusion: z.string(),
+    fulfillRequirements: z.array(z.string().regex(validModuleRegex)),
+    prereqTree,
+  })
+  .strict()
+
+/**
+ * all entities are strict, so if extra properties are passed,
+ * then the endpoint throws an error.
+ */
+const entities = {
+  /** FLATTENED */
+  User: z
+    .object({
+      id: z.string().uuid(),
+      facebookId: z.string(),
+      googleId: z.string(),
+      githubId: z.string(),
+      displayName: z.string(),
+      username: z.string(),
+      email: z.string().email(),
+      matriculationYear: z.number(),
+      graduationYear: z.number(),
+      graduationSemester: z.number(),
+      modulesDone: z.array(z.string().regex(validModuleRegex)),
+      modulesDoing: z.array(z.string().regex(validModuleRegex)),
+      savedDegrees: z.array(z.string().uuid()),
+      savedGraphs: z.array(z.string().uuid()),
+      /** allow empty string for CREATE endpoint */
+      mainDegree: z.string().uuid().or(z.string()),
+      mainGraph: z.string().uuid().or(z.string()),
+    })
+    .strict(),
+  Module,
+  ModuleCondensed: z
+    .object({
+      id: z.string().uuid(),
+      moduleCode: z.string().regex(validModuleRegex),
+      title: z.string(),
+    })
+    .strict(),
   ModuleFull: Module.extend({
     acadYear: z.string(),
     description: z.string(),
@@ -120,44 +133,48 @@ const entities = {
     workload: z.string().or(z.array(z.number())),
   }),
   /** FLATTENED */
-  Degree: z.object({
-    id: z.string().uuid(),
-    title: z.string(),
-    modules: z.array(z.string().regex(validModuleRegex)),
-  }),
-  /** FLATTENED */
-  Graph: z.object({
-    id: z.string().uuid(),
-    title: z.string(),
-    user: z.string().uuid(),
-    degree: z.object({
+  Degree: z
+    .object({
       id: z.string().uuid(),
       title: z.string(),
-    }),
-    modulesPlaced: z.array(z.string().regex(validModuleRegex)),
-    modulesHidden: z.array(z.string().regex(validModuleRegex)),
-    /** irrelevant optional props are left out */
-    flowNodes: z.array(
-      z.object({
-        id: z.string(),
-        position: z.object({
-          x: z.number(),
-          y: z.number(),
-        }),
-        data: Module,
-        className: z.string().optional(),
-        selected: z.boolean().optional(),
-      })
-    ),
-    /** irrelevant optional props are left out */
-    flowEdges: z.array(
-      z.object({
-        id: z.string(),
-        source: z.string(),
-        target: z.string(),
-      })
-    ),
-  }),
+      modules: z.array(z.string().regex(validModuleRegex)),
+    })
+    .strict(),
+  /** FLATTENED */
+  Graph: z
+    .object({
+      id: z.string().uuid(),
+      title: z.string(),
+      user: z.string().uuid(),
+      degree: z.object({
+        id: z.string().uuid(),
+        title: z.string(),
+      }),
+      modulesPlaced: z.array(z.string().regex(validModuleRegex)),
+      modulesHidden: z.array(z.string().regex(validModuleRegex)),
+      /** irrelevant optional props are left out */
+      flowNodes: z.array(
+        z.object({
+          id: z.string(),
+          position: z.object({
+            x: z.number(),
+            y: z.number(),
+          }),
+          data: Module,
+          className: z.string().optional(),
+          selected: z.boolean().optional(),
+        })
+      ),
+      /** irrelevant optional props are left out */
+      flowEdges: z.array(
+        z.object({
+          id: z.string(),
+          source: z.string(),
+          target: z.string(),
+        })
+      ),
+    })
+    .strict(),
 }
 
 export { deleteResult, entities }

--- a/apps/server/src/trpc/degree.ts
+++ b/apps/server/src/trpc/degree.ts
@@ -1,6 +1,7 @@
 import { flatten, validModuleRegex } from '@modtree/utils'
 import { z } from 'zod'
 import { api } from '../main'
+import { deleteResult, entities } from '../schemas/entities'
 import { createRouter } from './router'
 
 export const degree = createRouter()
@@ -8,10 +9,18 @@ export const degree = createRouter()
    * create and save a degree
    */
   .mutation('create', {
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'POST',
+        path: '/degree',
+      },
+    },
     input: z.object({
       title: z.string().min(1),
       moduleCodes: z.array(z.string().regex(validModuleRegex)),
     }),
+    output: entities.Degree,
     async resolve({ input }) {
       return api.degreeRepo
         .initialize(input.title, input.moduleCodes)
@@ -20,22 +29,22 @@ export const degree = createRouter()
   })
 
   /**
-   * get a full degree by id
-   */
-  .query('get-full', {
-    input: z.string().uuid(),
-    async resolve({ input }) {
-      return api.degreeRepo.findOneById(input)
-    },
-  })
-
-  /**
    * hard-delete a degree
    */
   .query('delete', {
-    input: z.string().uuid(),
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'DELETE',
+        path: '/degree/{degreeId}',
+      },
+    },
+    input: z.object({
+      degreeId: z.string().uuid(),
+    }),
+    output: deleteResult,
     async resolve({ input }) {
-      return api.degreeRepo.delete(input)
+      return api.degreeRepo.delete(input.degreeId)
     },
   })
 
@@ -43,11 +52,19 @@ export const degree = createRouter()
    * modifies a degree
    */
   .mutation('update', {
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'PATCH',
+        path: '/degree/{degreeId}',
+      },
+    },
     input: z.object({
       degreeId: z.string().uuid(),
       title: z.string().min(1),
       moduleCodes: z.array(z.string().regex(validModuleRegex)),
     }),
+    output: entities.Degree,
     async resolve({ input }) {
       return api.degreeRepo
         .findOneById(input.degreeId)

--- a/apps/server/src/trpc/get-one.ts
+++ b/apps/server/src/trpc/get-one.ts
@@ -2,52 +2,113 @@ import { flatten, validModuleRegex } from '@modtree/utils'
 import { z } from 'zod'
 import { createRouter } from './router'
 import { api } from '../main'
+import { entities } from '../schemas/entities'
 
 export const getOne = createRouter()
-  /** get a module by id */
+  /** get a module by code */
   .query('module', {
-    input: z.string().regex(validModuleRegex),
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'GET',
+        path: '/module/{moduleCode}',
+      },
+    },
+    input: z.object({
+      moduleCode: z.string().regex(validModuleRegex),
+    }),
+    output: entities.Module,
     async resolve({ input }) {
-      return api.moduleRepo.findByCode(input)
+      return api.moduleRepo.findByCode(input.moduleCode)
     },
   })
 
-  /** get a condensed module by id */
+  /** get a condensed module by code */
   .query('module-condensed', {
-    input: z.string().regex(validModuleRegex),
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'GET',
+        path: '/module-condensed/{moduleCode}',
+      },
+    },
+    input: z.object({
+      moduleCode: z.string().regex(validModuleRegex),
+    }),
+    output: entities.ModuleCondensed,
     async resolve({ input }) {
-      return api.moduleCondensedRepo.findByCode(input)
+      return api.moduleCondensedRepo.findByCode(input.moduleCode)
     },
   })
 
-  /** get a full module by id */
+  /** get a full module by code */
   .query('module-full', {
-    input: z.string().regex(validModuleRegex),
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'GET',
+        path: '/module-full/{moduleCode}',
+      },
+    },
+    input: z.object({
+      moduleCode: z.string().regex(validModuleRegex),
+    }),
+    output: entities.ModuleFull,
     async resolve({ input }) {
-      return api.moduleFullRepo.findByCode(input)
+      return api.moduleFullRepo.findByCode(input.moduleCode)
     },
   })
 
   /** get a degree by id */
   .query('degree', {
-    input: z.string().uuid(),
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'GET',
+        path: '/degree/{degreeId}',
+      },
+    },
+    input: z.object({
+      degreeId: z.string().uuid(),
+    }),
+    output: entities.Degree,
     async resolve({ input }) {
-      return api.degreeRepo.findOneById(input).then(flatten.degree)
+      return api.degreeRepo.findOneById(input.degreeId).then(flatten.degree)
     },
   })
 
   /** get a user by id */
   .query('user', {
-    input: z.string().uuid(),
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'GET',
+        path: '/user/{userId}',
+      },
+    },
+    input: z.object({
+      userId: z.string().uuid(),
+    }),
+    output: entities.User,
     async resolve({ input }) {
-      return api.userRepo.findOneById(input).then(flatten.user)
+      return api.userRepo.findOneById(input.userId).then(flatten.user)
     },
   })
 
   /** get a graph by id */
   .query('graph', {
-    input: z.string().uuid(),
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'GET',
+        path: '/graph/{graphId}',
+      },
+    },
+    input: z.object({
+      graphId: z.string().uuid(),
+    }),
+    output: entities.Graph,
     async resolve({ input }) {
-      return api.graphRepo.findOneById(input).then(flatten.graph)
+      return api.graphRepo.findOneById(input.graphId).then(flatten.graph)
     },
   })

--- a/apps/server/src/trpc/graph.ts
+++ b/apps/server/src/trpc/graph.ts
@@ -1,6 +1,7 @@
 import { flatten, validModuleRegex } from '@modtree/utils'
 import { z } from 'zod'
 import { api } from '../main'
+import { deleteResult, entities } from '../schemas/entities'
 import { createRouter } from './router'
 
 export const graph = createRouter()
@@ -8,11 +9,19 @@ export const graph = createRouter()
    * create and save a graph
    */
   .mutation('create', {
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'POST',
+        path: '/graph',
+      },
+    },
     input: z.object({
       title: z.string().min(1).default('Untitled'),
       userId: z.string().uuid(),
       degreeId: z.string().uuid(),
     }),
+    output: entities.Graph,
     async resolve({ input }) {
       return api.graphRepo
         .initialize(input.title, input.userId, input.degreeId)
@@ -21,33 +30,45 @@ export const graph = createRouter()
   })
 
   /**
-   * get a full graph by id
-   */
-  .query('get-full', {
-    input: z.string().uuid(),
-    async resolve({ input }) {
-      return api.graphRepo.findOneById(input)
-    },
-  })
-
-  /**
    * hard-delete a graph
    */
   .query('delete', {
-    input: z.string().uuid(),
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'DELETE',
+        path: '/graph/{graphId}',
+      },
+    },
+    input: z.object({
+      graphId: z.string().uuid(),
+    }),
+    output: deleteResult,
     async resolve({ input }) {
-      return api.graphRepo.delete(input)
+      return api.graphRepo.delete(input.graphId)
     },
   })
 
   /**
-   * finds a graph by its id and updates a flow node
+   * suggest modules
+   *
+   * FIXME
+   * GET request only accepts string params in input properties
    */
-  .query('suggest-modules', {
+  .mutation('suggest-modules', {
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'POST',
+        path: '/graph/{graphId}/suggest-modules',
+      },
+    },
     input: z.object({
       graphId: z.string().uuid(),
       selectedCodes: z.array(z.string().regex(validModuleRegex)),
     }),
+    /* array of module codes */
+    output: z.array(z.string().regex(validModuleRegex)),
     async resolve({ input }) {
       return api.graphRepo
         .findOneById(input.graphId)
@@ -63,10 +84,25 @@ export const graph = createRouter()
    * Returns a dictionary keyed on moduleCode.
    */
   .query('can-take-modules', {
-    input: z.string().uuid(),
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'GET',
+        path: '/graph/{graphId}/can-take-modules',
+      },
+    },
+    input: z.object({
+      graphId: z.string().uuid(),
+    }),
+    output: z.array(
+      z.object({
+        moduleCode: z.string().regex(validModuleRegex),
+        canTake: z.boolean(),
+      })
+    ),
     async resolve({ input }) {
       return api.graphRepo
-        .findOneById(input)
+        .findOneById(input.graphId)
         .then((g) => api.graphRepo.canTakeModules(g))
     },
   })
@@ -75,10 +111,18 @@ export const graph = createRouter()
    * finds a graph by its id and update title
    */
   .mutation('rename', {
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'PATCH',
+        path: '/graph/{graphId}',
+      },
+    },
     input: z.object({
       graphId: z.string().uuid(),
       title: z.string(),
     }),
+    output: entities.Graph,
     async resolve({ input }) {
       return api.graphRepo
         .findOneById(input.graphId)
@@ -89,11 +133,13 @@ export const graph = createRouter()
 
   /**
    * updates a graph
+   * FIXME
    */
   .mutation('update', {
     input: z.object({
       graph: z.any(),
     }),
+    output: z.any(),
     async resolve({ input }) {
       return api.graphRepo.update(input.graph).then((res) => ({
         ...res,

--- a/apps/server/src/trpc/list.ts
+++ b/apps/server/src/trpc/list.ts
@@ -1,39 +1,79 @@
-import { flatten, validModuleRegex } from '@modtree/utils'
+import { flatten } from '@modtree/utils'
 import { z } from 'zod'
 import { createRouter } from './router'
 import { api } from '../main'
+import { entities } from '../schemas/entities'
+import { parseCommaSeparatedString } from '../utils/parse'
 
 export const list = createRouter()
   /** list modules */
   .query('modules', {
-    input: z.array(z.string().regex(validModuleRegex)),
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'GET',
+        path: '/modules',
+      },
+    },
+    input: z.object({
+      moduleCodes: z.string().transform(parseCommaSeparatedString),
+    }),
+    output: z.array(entities.Module),
     async resolve({ input }) {
-      return api.moduleRepo.findByCodes(input)
+      return api.moduleRepo.findByCodes(input.moduleCodes)
     },
   })
 
   /** list condensed modules */
   .query('modules-condensed', {
-    input: z.array(z.string().regex(validModuleRegex)),
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'GET',
+        path: '/modules-condensed',
+      },
+    },
+    input: z.object({
+      moduleCodes: z.string().transform(parseCommaSeparatedString),
+    }),
+    output: z.array(entities.ModuleCondensed),
     async resolve({ input }) {
-      return api.moduleCondensedRepo.findByCodes(input)
+      return api.moduleCondensedRepo.findByCodes(input.moduleCodes)
     },
   })
 
   /** list full modules */
   .query('modules-full', {
-    input: z.array(z.string().regex(validModuleRegex)),
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'GET',
+        path: '/modules-full',
+      },
+    },
+    input: z.object({
+      moduleCodes: z.string().transform(parseCommaSeparatedString),
+    }),
+    output: z.array(entities.ModuleFull),
     async resolve({ input }) {
-      return api.moduleFullRepo.findByCodes(input)
+      return api.moduleFullRepo.findByCodes(input.moduleCodes)
     },
   })
 
   /** list users */
   .query('users', {
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'GET',
+        path: '/users',
+      },
+    },
     input: z.object({
-      id: z.string().uuid().optional(),
-      email: z.string().email().optional(),
+      id: z.string().uuid(),
+      email: z.string().email(),
     }),
+    output: z.array(entities.User),
     async resolve({ input }) {
       return api.userRepo
         .find({
@@ -49,20 +89,40 @@ export const list = createRouter()
 
   /** list degrees */
   .query('degrees', {
-    input: z.array(z.string().uuid()),
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'GET',
+        path: '/degrees',
+      },
+    },
+    input: z.object({
+      degreeIds: z.string().transform(parseCommaSeparatedString),
+    }),
+    output: z.array(entities.Degree),
     async resolve({ input }) {
       return api.degreeRepo
-        .findByIds(input)
+        .findByIds(input.degreeIds)
         .then((degrees) => degrees.map(flatten.degree))
     },
   })
 
   /** list graphs */
   .query('graphs', {
-    input: z.array(z.string().uuid()),
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'GET',
+        path: '/graphs',
+      },
+    },
+    input: z.object({
+      graphIds: z.string().transform(parseCommaSeparatedString),
+    }),
+    output: z.array(entities.Graph),
     async resolve({ input }) {
       return api.graphRepo
-        .findByIds(input)
+        .findByIds(input.graphIds)
         .then((graphs) => graphs.map(flatten.graph))
     },
   })

--- a/apps/server/src/trpc/router.ts
+++ b/apps/server/src/trpc/router.ts
@@ -1,4 +1,5 @@
 import { router } from '@trpc/server'
+import { OpenApiMeta } from 'trpc-openapi'
 
 /** keep this to be able to inject a custom router/context in the future */
-export const createRouter = () => router()
+export const createRouter = () => router<any, OpenApiMeta>()

--- a/apps/server/src/trpc/search.ts
+++ b/apps/server/src/trpc/search.ts
@@ -13,18 +13,18 @@ export const search = createRouter()
       openapi: {
         enabled: true,
         method: 'GET',
-        path: '/search/modules/{search}',
+        path: '/search/modules/{query}',
       },
     },
     input: z.object({
-      search: z.string(),
+      query: z.string(),
     }),
     output: z.array(entities.Module),
     async resolve({ input }) {
       if (!input) return []
       return api.moduleCondensedRepo
         .find({
-          where: [{ moduleCode: Like(`${input.search.toUpperCase()}%`) }],
+          where: [{ moduleCode: Like(`${input.query.toUpperCase()}%`) }],
           take: 4,
         })
         .then((r) =>
@@ -41,17 +41,17 @@ export const search = createRouter()
       openapi: {
         enabled: true,
         method: 'GET',
-        path: '/search/modules-condensed/{search}',
+        path: '/search/modules-condensed/{query}',
       },
     },
     input: z.object({
-      search: z.string(),
+      query: z.string(),
     }),
     output: z.array(entities.ModuleCondensed),
     async resolve({ input }) {
       if (!input) return []
       return api.moduleCondensedRepo.find({
-        where: [{ moduleCode: Like(`${input.search.toUpperCase()}%`) }],
+        where: [{ moduleCode: Like(`${input.query.toUpperCase()}%`) }],
         take: 4,
       })
     },

--- a/apps/server/src/trpc/search.ts
+++ b/apps/server/src/trpc/search.ts
@@ -1,6 +1,7 @@
 import { Like } from 'typeorm'
 import { z } from 'zod'
 import { api } from '../main'
+import { entities } from '../schemas/entities'
 import { createRouter } from './router'
 
 export const search = createRouter()
@@ -8,12 +9,22 @@ export const search = createRouter()
    * search for modules
    */
   .query('modules', {
-    input: z.string(),
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'GET',
+        path: '/search/modules/{search}',
+      },
+    },
+    input: z.object({
+      search: z.string(),
+    }),
+    output: z.array(entities.Module),
     async resolve({ input }) {
       if (!input) return []
       return api.moduleCondensedRepo
         .find({
-          where: [{ moduleCode: Like(`${input.toUpperCase()}%`) }],
+          where: [{ moduleCode: Like(`${input.search.toUpperCase()}%`) }],
           take: 4,
         })
         .then((r) =>
@@ -26,11 +37,21 @@ export const search = createRouter()
    * search for modules condensed
    */
   .query('modules-condensed', {
-    input: z.string(),
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'GET',
+        path: '/search/modules-condensed/{search}',
+      },
+    },
+    input: z.object({
+      search: z.string(),
+    }),
+    output: z.array(entities.ModuleCondensed),
     async resolve({ input }) {
       if (!input) return []
       return api.moduleCondensedRepo.find({
-        where: [{ moduleCode: Like(`${input.toUpperCase()}%`) }],
+        where: [{ moduleCode: Like(`${input.search.toUpperCase()}%`) }],
         take: 4,
       })
     },

--- a/apps/server/src/trpc/user.ts
+++ b/apps/server/src/trpc/user.ts
@@ -2,6 +2,7 @@ import { ModuleStatus } from '@modtree/types'
 import { flatten, validModuleRegex } from '@modtree/utils'
 import { z } from 'zod'
 import { api } from '../main'
+import { deleteResult, entities } from '../schemas/entities'
 import { createRouter } from './router'
 
 export const user = createRouter()
@@ -9,11 +10,19 @@ export const user = createRouter()
    * create a user
    */
   .mutation('create', {
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'POST',
+        path: '/user',
+      },
+    },
     input: z.object({
       email: z.string().email(),
       provider: z.string().optional(),
       providerId: z.string().optional(),
     }),
+    output: entities.User,
     async resolve({ input }) {
       return api.userRepo
         .initialize(input.email, input.provider, input.providerId)
@@ -25,19 +34,19 @@ export const user = createRouter()
    * hard-deletes a user by id
    */
   .query('delete', {
-    input: z.string().uuid(),
-    async resolve({ input }) {
-      return api.userRepo.delete(input)
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'DELETE',
+        path: '/user/{userId}',
+      },
     },
-  })
-
-  /**
-   * get a full user
-   */
-  .query('get-full', {
-    input: z.string().uuid(),
+    input: z.object({
+      userId: z.string().uuid(),
+    }),
+    output: deleteResult,
     async resolve({ input }) {
-      return api.userRepo.findOneById(input).then(flatten.user)
+      return api.userRepo.delete(input.userId)
     },
   })
 
@@ -45,10 +54,18 @@ export const user = createRouter()
    * insert degrees into user
    */
   .mutation('insert-degrees', {
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'PATCH',
+        path: '/user/{userId}/insert-degrees',
+      },
+    },
     input: z.object({
       userId: z.string().uuid(),
       degreeIds: z.array(z.string().uuid()),
     }),
+    output: entities.User,
     async resolve({ input }) {
       return api.userRepo
         .findOneById(input.userId)
@@ -61,10 +78,18 @@ export const user = createRouter()
    * set main degree of user
    */
   .mutation('set-main-degree', {
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'PATCH',
+        path: '/user/{userId}/set-main-degree',
+      },
+    },
     input: z.object({
       userId: z.string().uuid(),
       degreeId: z.string().uuid(),
     }),
+    output: entities.User,
     async resolve({ input }) {
       return api.userRepo
         .findOneById(input.userId)
@@ -77,10 +102,18 @@ export const user = createRouter()
    * remove degree from user
    */
   .mutation('remove-degree', {
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'PATCH',
+        path: '/user/{userId}/remove-degree',
+      },
+    },
     input: z.object({
       userId: z.string().uuid(),
       degreeId: z.string().uuid(),
     }),
+    output: entities.User,
     async resolve({ input }) {
       return api.userRepo
         .findOneById(input.userId)
@@ -93,10 +126,18 @@ export const user = createRouter()
    * insert graphs into user
    */
   .mutation('insert-graphs', {
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'PATCH',
+        path: '/user/{userId}/insert-graphs',
+      },
+    },
     input: z.object({
       userId: z.string().uuid(),
       graphIds: z.array(z.string().uuid()),
     }),
+    output: entities.User,
     async resolve({ input }) {
       return api.userRepo
         .findOneById(input.userId)
@@ -109,10 +150,18 @@ export const user = createRouter()
    * set main graph of user
    */
   .mutation('set-main-graph', {
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'PATCH',
+        path: '/user/{userId}/set-main-graph',
+      },
+    },
     input: z.object({
       userId: z.string().uuid(),
       graphId: z.string().uuid(),
     }),
+    output: entities.User,
     async resolve({ input }) {
       return api.userRepo
         .findOneById(input.userId)
@@ -125,10 +174,18 @@ export const user = createRouter()
    * remove graph from user
    */
   .mutation('remove-graph', {
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'PATCH',
+        path: '/user/{userId}/remove-graph',
+      },
+    },
     input: z.object({
       userId: z.string().uuid(),
       graphId: z.string().uuid(),
     }),
+    output: entities.User,
     async resolve({ input }) {
       return api.userRepo
         .findOneById(input.userId)
@@ -141,11 +198,19 @@ export const user = createRouter()
    * sets module status of a user
    */
   .mutation('set-module-status', {
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'PATCH',
+        path: '/user/{userId}/set-module-status',
+      },
+    },
     input: z.object({
       userId: z.string().uuid(),
       moduleCodes: z.array(z.string().regex(validModuleRegex)),
       status: z.nativeEnum(ModuleStatus),
     }),
+    output: entities.User,
     async resolve({ input }) {
       return api.userRepo
         .findOneById(input.userId)
@@ -160,11 +225,19 @@ export const user = createRouter()
    * user login
    */
   .mutation('login', {
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'POST',
+        path: '/user/login',
+      },
+    },
     input: z.object({
       provider: z.string(),
       providerId: z.string().min(1),
       email: z.string().email(),
     }),
+    output: entities.User,
     async resolve({ input }) {
       return api
         .userLogin(input.email, input.provider, input.providerId)
@@ -176,8 +249,18 @@ export const user = createRouter()
    * get a user by email
    */
   .query('get-by-email', {
-    input: z.string().email(),
+    meta: {
+      openapi: {
+        enabled: true,
+        method: 'GET',
+        path: '/user/get-by-email',
+      },
+    },
+    input: z.object({
+      email: z.string().email(),
+    }),
+    output: entities.User,
     async resolve({ input }) {
-      return api.userRepo.findOneByEmail(input).then(flatten.user)
+      return api.userRepo.findOneByEmail(input.email).then(flatten.user)
     },
   })

--- a/apps/server/src/utils/parse.spec.ts
+++ b/apps/server/src/utils/parse.spec.ts
@@ -1,0 +1,33 @@
+import { parseCommaSeparatedString } from './parse'
+
+const correct = [
+  {
+    type: 'one moduleCode',
+    input: 'CS1010',
+    expected: ['CS1010'],
+  },
+  {
+    type: 'multiple moduleCodes',
+    input: 'CS1010, MA2001, EL1101E',
+    expected: ['CS1010', 'MA2001', 'EL1101E'],
+  },
+  {
+    type: 'one quoted UUID',
+    input: '009c5671-2e9c-4b15-850b-0469f7c8f62f',
+    expected: ['009c5671-2e9c-4b15-850b-0469f7c8f62f'],
+  },
+  {
+    type: 'one quoted string',
+    input: 'sample',
+    expected: ['sample'],
+  },
+  {
+    type: 'undefined input',
+    expected: [],
+  },
+]
+
+test.each(correct)('$type', (props) => {
+  const { input, expected } = props
+  expect(parseCommaSeparatedString(input)).toStrictEqual(expected)
+})

--- a/apps/server/src/utils/parse.ts
+++ b/apps/server/src/utils/parse.ts
@@ -1,0 +1,22 @@
+/**
+ * Converts a comma separated string into a string array.
+ *
+ * If any input checks fail, return empty array.
+ */
+export function parseCommaSeparatedString(input: string) {
+  /** input checking **/
+  // assert string
+  const isString = typeof input === 'string'
+  if (!isString) {
+    return []
+  }
+
+  /** assume string is safe **/
+  const a = input
+    // remove trailing and preceding whitespaces
+    .trim()
+    .split(',')
+    // trim whitespaces in each module code
+    .map((element) => element.trim())
+  return a
+}

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -2,6 +2,9 @@
   "extends": "../../tsconfig.base.json",
   "files": [],
   "include": [],
+  "compilerOptions": {
+    "strict": true
+  },
   "references": [
     {
       "path": "./tsconfig.app.json"

--- a/apps/web/components/modals/module-info/contents.tsx
+++ b/apps/web/components/modals/module-info/contents.tsx
@@ -20,7 +20,19 @@ export function ModuleDetails() {
     // 1. hide module modal
     dispatch(r.hideModuleModal())
     // 2. add module to graph
-    addModuleNode(nodify(module, 'planned'))
+    const data = {
+      // basically extract IModule from IFull
+      id: module.id,
+      moduleCode: module.moduleCode,
+      title: module.title,
+      prerequisite: module.prerequisite,
+      corequisite: module.corequisite,
+      preclusion: module.preclusion,
+      fulfillRequirements: module.fulfillRequirements,
+      prereqTree: module.prereqTree,
+    }
+    /** typescript not getting the type right here */
+    addModuleNode(nodify(data, 'planned'))
   }
 
   return (

--- a/apps/web/components/user-profile/degrees/main.tsx
+++ b/apps/web/components/user-profile/degrees/main.tsx
@@ -14,9 +14,12 @@ export function Main(props: {
 
   // Get IDs
   const degreeIds = useAppSelector((s) => s.modtree.user.savedDegrees)
-  const { data: degrees } = trpcReact.useQuery(['degrees', degreeIds], {
-    keepPreviousData: true,
-  })
+  const { data: degrees } = trpcReact.useQuery(
+    ['degrees', { degreeIds: degreeIds.join(',') }],
+    {
+      keepPreviousData: true,
+    }
+  )
 
   return (
     <div className="mb-12">

--- a/apps/web/components/user-profile/graphs/main.tsx
+++ b/apps/web/components/user-profile/graphs/main.tsx
@@ -18,12 +18,18 @@ export function Main(props: {
   /** hooks */
   const user = useAppSelector((s) => s.modtree.user)
   const graph = useAppSelector((s) => s.graph)
-  const { data: degrees } = trpcReact.useQuery(['degrees', user.savedDegrees], {
-    keepPreviousData: true,
-  })
-  const { data: graphs } = trpcReact.useQuery(['graphs', user.savedGraphs], {
-    keepPreviousData: true,
-  })
+  const { data: degrees } = trpcReact.useQuery(
+    ['degrees', { degreeIds: user.savedDegrees.join(',') }],
+    {
+      keepPreviousData: true,
+    }
+  )
+  const { data: graphs } = trpcReact.useQuery(
+    ['graphs', { graphIds: user.savedGraphs.join(',') }],
+    {
+      keepPreviousData: true,
+    }
+  )
 
   return (
     <>

--- a/apps/web/pages/api/auth/[...nextauth].ts
+++ b/apps/web/pages/api/auth/[...nextauth].ts
@@ -70,7 +70,7 @@ export default NextAuth({
         return session
       }
       return trpc
-        .query('user/get-by-email', email)
+        .query('user/get-by-email', { email })
         .then((user) => {
           /** reload the user's id here */
           session.user.modtreeId = user.id

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -19,15 +19,15 @@ export default function Modtree() {
 
   /** trpc hooks that will auto-refetch upon any change in request params */
   const opts = { keepPreviousData: true, enabled: status === 'authenticated' }
-  trpcReact.useQuery(['user', user ? user.modtreeId : ''], {
+  trpcReact.useQuery(['user', { userId: user ? user.modtreeId : '' }], {
     onSuccess: (user) => dispatch(r.setUser(user)),
     ...opts,
   })
-  trpcReact.useQuery(['degree', state.user.mainDegree], {
+  trpcReact.useQuery(['degree', { degreeId: state.user.mainDegree }], {
     onSuccess: (degree) => dispatch(r.setMainDegree(degree)),
     ...opts,
   })
-  trpcReact.useQuery(['graph', state.user.mainGraph], {
+  trpcReact.useQuery(['graph', { graphId: state.user.mainGraph }], {
     onSuccess: (graph) => dispatch(r.setMainGraph(graph)),
     ...opts,
   })

--- a/apps/web/store/functions.ts
+++ b/apps/web/store/functions.ts
@@ -34,7 +34,7 @@ export function redrawGraph() {
  */
 export function openModuleModal(query: string) {
   trpc
-    .query('module-full', query)
+    .query('module-full', { moduleCode: query })
     .then((module) => dispatch(r.setModalModule(module)))
     .then(() => dispatch(r.showModuleModal()))
 }
@@ -100,10 +100,12 @@ export function updateModuleCache(moduleCodes: string[]) {
   if (codesToFetch.length === 0) return
 
   /** send the http request */
-  return trpc.query('modules', codesToFetch).then((modules) => {
-    /** update the redux store */
-    dispatch(r.addModulesToCache(modules))
-  })
+  return trpc
+    .query('modules', { moduleCodes: codesToFetch.join(',') })
+    .then((modules) => {
+      /** update the redux store */
+      dispatch(r.addModulesToCache(modules))
+    })
 }
 
 /**
@@ -190,8 +192,10 @@ export function renameGraph(graphId: string, title: string) {
  */
 export function setBuildTarget(degreeId: string) {
   trpc
-    .query('degree', degreeId)
-    .then((degree) => trpc.query('modules', degree.modules))
+    .query('degree', { degreeId })
+    .then((degree) =>
+      trpc.query('modules', { moduleCodes: degree.modules.join(',') })
+    )
     .then((modules) => {
       dispatch(r.addModulesToCache(modules))
       dispatch(r.setBuildList(modules.map((m) => m.moduleCode)))
@@ -204,7 +208,7 @@ export function setBuildTarget(degreeId: string) {
  * @param {string} moduleCode
  */
 export function addModuleToBuildList(moduleCode: string) {
-  trpc.query('module', moduleCode).then((module) => {
+  trpc.query('module', { moduleCode }).then((module) => {
     dispatch(r.addModulesToCache([module]))
     dispatch(r.addToBuildList(moduleCode))
   })
@@ -225,7 +229,7 @@ export function updateDegree(
   const { user } = store.getState().modtree
   trpc
     .mutation('degree/update', { degreeId, title, moduleCodes })
-    .then(() => trpc.query('user', user.id))
+    .then(() => trpc.query('user', { userId: user.id }))
     .then((user) => dispatch(r.setUser(user)))
 }
 

--- a/apps/web/ui/search/degree/degree-picker.tsx
+++ b/apps/web/ui/search/degree/degree-picker.tsx
@@ -10,9 +10,12 @@ export function DegreePicker(props: {
 }) {
   const [degree, setDegree] = props.degreeState
   const { user } = useAppSelector((s) => s.modtree)
-  const { data: degrees } = trpcReact.useQuery(['degrees', user.savedDegrees], {
-    keepPreviousData: true,
-  })
+  const { data: degrees } = trpcReact.useQuery(
+    ['degrees', { degreeIds: user.savedDegrees.join(',') }],
+    {
+      keepPreviousData: true,
+    }
+  )
 
   /**
    * the thing you press to open the picker

--- a/apps/web/ui/search/graph/graph-picker.tsx
+++ b/apps/web/ui/search/graph/graph-picker.tsx
@@ -12,13 +12,16 @@ export function GraphPicker() {
   const graph = useAppSelector((s) => s.graph)
   const dispatch = useAppDispatch()
   const trpc = trpcReact.useContext()
-  const { data: graphs } = trpcReact.useQuery(['graphs', user.savedGraphs], {
-    keepPreviousData: true,
-    onSuccess: (graphs) => {
-      const match = graphs.find((g) => g.id === graph.id)
-      if (match) dispatch(r.setMainGraph(match))
-    },
-  })
+  const { data: graphs } = trpcReact.useQuery(
+    ['graphs', { graphIds: user.savedGraphs.join(',') }],
+    {
+      keepPreviousData: true,
+      onSuccess: (graphs) => {
+        const match = graphs.find((g) => g.id === graph.id)
+        if (match) dispatch(r.setMainGraph(match))
+      },
+    }
+  )
   const setMain = trpcReact.useMutation(['user/set-main-graph'])
 
   /**

--- a/apps/web/ui/search/module/input.tsx
+++ b/apps/web/ui/search/module/input.tsx
@@ -15,7 +15,7 @@ export function SearchInput(props: {
   const [query, setQuery] = useState('')
   const dispatch = useAppDispatch()
 
-  trpcReact.useQuery(['search/modules', query], {
+  trpcReact.useQuery(['search/modules', { search: query }], {
     keepPreviousData: true,
     onSuccess: (modules) => dispatch(r.setSearchedModule(modules)),
   })

--- a/apps/web/ui/search/module/input.tsx
+++ b/apps/web/ui/search/module/input.tsx
@@ -15,7 +15,7 @@ export function SearchInput(props: {
   const [query, setQuery] = useState('')
   const dispatch = useAppDispatch()
 
-  trpcReact.useQuery(['search/modules', { search: query }], {
+  trpcReact.useQuery(['search/modules', { query }], {
     keepPreviousData: true,
     onSuccess: (modules) => dispatch(r.setSearchedModule(modules)),
   })

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   db_web:
-    image: 'modtree/postgres:0.8.0'
+    image: 'modtree/postgres:0.8.1'
     profiles: ['all', 'db']
     ports:
       - '4000:5432'
@@ -10,7 +10,7 @@ services:
       POSTGRES_USER: web
       POSTGRES_PASSWORD: web
   db_test:
-    image: 'modtree/postgres:0.8.0'
+    image: 'modtree/postgres:0.8.1'
     profiles: ['all', 'db']
     ports:
       - '4001:5432'

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "reflect-metadata": "^0.1.13",
     "regenerator-runtime": "0.13.7",
     "swr": "^1.3.0",
+    "trpc-openapi": "^0.4.0",
     "tslib": "^2.3.0",
     "typeorm": "^0.3.7",
     "zod": "^3.17.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4326,6 +4326,16 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
+co-body@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/co-body/-/co-body-6.1.0.tgz#d87a8efc3564f9bfe3aced8ef5cd04c7a8766547"
+  integrity sha512-m7pOT6CdLN7FuXUcpuz/8lfQ/L77x8SchHCF4G0RBTJO20Wzmhn5Sp4/5WsKy8OSpifBSUrmg83qEqaDHdyFuQ==
+  dependencies:
+    inflation "^2.0.0"
+    qs "^6.5.2"
+    raw-body "^2.3.3"
+    type-is "^1.6.16"
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -6794,6 +6804,11 @@ indent-string@^4.0.0:
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
+inflation@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/inflation/-/inflation-2.0.0.tgz#8b417e47c28f925a45133d914ca1fd389107f30f"
+  integrity sha512-m3xv4hJYR2oXw4o4Y5l6P5P16WYmazYof+el6Al3f+YlggGj6qT9kImBAnzDelRALnP5d3h4jGBPKzYCizjZZw==
+
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -7864,6 +7879,11 @@ lodash.castarray@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.castarray/-/lodash.castarray-4.4.0.tgz#c02513515e309daddd4c24c60cfddcf5976d9115"
   integrity sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==
 
+lodash.clonedeep@4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
@@ -8584,6 +8604,11 @@ open@^8.0.9, open@^8.4.0:
     define-lazy-prop "^2.0.0"
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
+
+openapi-types@12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/openapi-types/-/openapi-types-12.0.0.tgz#458a99d048f9eae1c067e15d56a8bfb3726041f1"
+  integrity sha512-6Wd9k8nmGQHgCbehZCP6wwWcfXcvinhybUTBatuhjRsCxUIujuYFZc9QnGeae75CyHASewBtxs0HX/qwREReUw==
 
 opener@^1.5.1:
   version "1.5.2"
@@ -9477,7 +9502,7 @@ qs@6.9.6:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.6.tgz#26ed3c8243a431b2924aca84cc90471f35d5a0ee"
   integrity sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==
 
-qs@^6.10.3, qs@^6.4.0:
+qs@^6.10.3, qs@^6.4.0, qs@^6.5.2:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
   integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
@@ -9521,7 +9546,7 @@ raw-body@2.4.2:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-raw-body@2.5.1:
+raw-body@2.5.1, raw-body@^2.3.3:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.1.tgz#fe1b1628b181b700215e5fd42389f98b71392857"
   integrity sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==
@@ -10861,6 +10886,16 @@ tree-kill@1.2.2:
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
+trpc-openapi@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/trpc-openapi/-/trpc-openapi-0.4.0.tgz#0fc682983c328b2cdb281ed5b56830ed84a553e4"
+  integrity sha512-a3/JuEoAhvN9Q73hx9vthjAm85JpEKQ9OiDgqsUZHUm0SFvqUK9WPkTradfepzJ1EbPdL2hEbwSIWZ2M/+WNOQ==
+  dependencies:
+    co-body "6.1.0"
+    lodash.clonedeep "4.5.0"
+    openapi-types "12.0.0"
+    zod-to-json-schema "3.17.0"
+
 ts-jest@27.1.4:
   version "27.1.4"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-27.1.4.tgz#84d42cf0f4e7157a52e7c64b1492c46330943e00"
@@ -10990,7 +11025,7 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
-type-is@~1.6.18:
+type-is@^1.6.16, type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
   integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
@@ -11631,6 +11666,11 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod-to-json-schema@3.17.0:
+  version "3.17.0"
+  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.17.0.tgz#dbfb61b10342c4d02fb2cacfa60d54d564e03458"
+  integrity sha512-Ioxmh41HTo4xAip7DPy79ysvGibPnDxzGoPNcNT+1dxwLjeXf/BruRnj7sRJAe2p4z8vTx6d62CXigEPTz6DqQ==
 
 zod@^3.17.3:
   version "3.17.3"


### PR DESCRIPTION
### Summary of changes

- feat: OpenAPI routes are mounted at `/api`
- BREAKING: params of API calls are passed via an object. Example below
- BREAKING: params of GET calls must be string. Hence, calls with string arrays now pass in a comma separated string instead. Example below
- fix: point to latest docker image

### Testing

E2E tests pass, except `new-graph.cy.ts > Add new graph`, which is the same on `main`
