### PR TITLE
fix: only release heroku builds on non-arm systems

### DIFF
--- a/docker/cy-reporter/build.js
+++ b/docker/cy-reporter/build.js
@@ -81,7 +81,12 @@ function buildNode() {
     tagImage()
     dockerLogin()
     pushImage()
-    herokuRelease()
+    if (!process.arch.startsWith('arm')) {
+      // only release on non-arm systems
+      herokuRelease()
+    } else {
+      console.log(yellow('Currently on ARM architecture; not releasing.'))
+    }
   })
 }
 


### PR DESCRIPTION
releasing a docker image built on an `arm` or `arm64` system will simply not run on Heroku's dyno.