### PR TITLE
feat: open cypress GUI from `yarn cy`

### DIFF
--- a/libs/cy-reporter/dev.js
+++ b/libs/cy-reporter/dev.js
@@ -1,5 +1,12 @@
 const Runner = require('../../scripts/runner')
 const compiler = require('./webpack')
+const hasArg = (a) => process.argv.slice(2).includes(a)
 
-const runner = new Runner(compiler, 'server.js')
+const file = (() => {
+  if (hasArg('--server')) return 'server.js'
+  if (hasArg('--cli')) return 'cli.js'
+  return ''
+})()
+
+const runner = new Runner(compiler, file)
 runner.run()

--- a/libs/cy-reporter/src/cli/help.ts
+++ b/libs/cy-reporter/src/cli/help.ts
@@ -9,6 +9,7 @@ COMMAND:
                     to have fzf prompt you for which test to run)
       ra, run-all   run all cypress tests
       ls, list      list cypress runs related to current commit
+      o, open       open the cypress graphical user interface
 
 OPTIONS
       -a, --all     run all tests (ls --all is not supported)

--- a/libs/cy-reporter/src/cli/index.ts
+++ b/libs/cy-reporter/src/cli/index.ts
@@ -33,7 +33,7 @@ if (opts.action === 'list') {
 }
 
 if (opts.action === 'open') {
-  fork(exe.list, { stdio: 'inherit' })
+  fork(exe.open, { stdio: 'inherit' })
 }
 
 // check for a clean git status before running

--- a/libs/cy-reporter/src/cli/index.ts
+++ b/libs/cy-reporter/src/cli/index.ts
@@ -19,31 +19,35 @@ const dir = {
 // dist
 const exe = {
   list: path.resolve(dir.dist, 'list.js'),
-  cypress: path.resolve(rootDir, 'scripts/cypress/run.js'),
+  run: path.resolve(rootDir, 'scripts/cypress/run.js'),
+  open: path.resolve(rootDir, 'scripts/cypress/open.js'),
 }
 
-if (opts.help) {
+if (opts.action === 'help') {
   console.log(helpText)
   process.exit(0)
 }
 
-if (opts.list) {
-  opts.run = false
+if (opts.action === 'list') {
+  fork(exe.list, { stdio: 'inherit' })
+}
+
+if (opts.action === 'open') {
   fork(exe.list, { stdio: 'inherit' })
 }
 
 // check for a clean git status before running
-if (opts.run && !isStatusClean()) {
+if (opts.action === 'run' && !isStatusClean()) {
   log.warn('Warning: git status is not clean.')
   if (!opts.force) process.exit(1)
 }
 
-if (opts.run && opts.all) {
+if (opts.action === 'run' && opts.all) {
   log.green('Running all tests')
-  fork(exe.cypress, ['--all'])
+  fork(exe.run, ['--all'])
 }
 
-if (opts.run && !opts.all) {
+if (opts.action === 'run' && !opts.all) {
   const fzf = spawn(
     'fzf',
     [
@@ -68,6 +72,6 @@ if (opts.run && !opts.all) {
   fzf.stdout.on('data', (data: string) => {
     const target = data.trim()
     log.green('Running test:', target)
-    fork(exe.cypress, [path.resolve(dir.spec, target)])
+    fork(exe.run, [path.resolve(dir.spec, target)])
   })
 }

--- a/libs/cy-reporter/src/cli/parse-args.ts
+++ b/libs/cy-reporter/src/cli/parse-args.ts
@@ -6,11 +6,13 @@ import type { Parser, Options } from './types'
 
 // default options
 const opts: Options = {
+  action: 'unset',
   force: false,
   all: false,
-  run: false,
-  list: false,
-  help: false,
+}
+
+function setAction(action: Options['action']) {
+  if (opts.action === 'unset') opts.action = action
 }
 
 const parsers: Parser[] = [
@@ -23,7 +25,7 @@ const parsers: Parser[] = [
   {
     arg: ['-h', '--help'],
     type: 'boolean',
-    callback: () => (opts.help = true),
+    callback: () => setAction('help'),
   },
   {
     arg: ['-a', '--all'],
@@ -34,25 +36,30 @@ const parsers: Parser[] = [
   {
     arg: ['r', 'run'],
     type: 'boolean',
-    callback: () => (opts.run = true),
+    callback: () => setAction('run'),
   },
   {
     arg: ['ra', 'run-all'],
     type: 'boolean',
     callback: () => {
-      opts.run = true
+      setAction('run')
       opts.all = true
     },
   },
   {
     arg: ['ls', 'list'],
     type: 'boolean',
-    callback: () => (opts.list = true),
+    callback: () => setAction('list'),
+  },
+  {
+    arg: ['o', 'open'],
+    type: 'boolean',
+    callback: () => setAction('open'),
   },
 ]
 
 const args = process.argv.slice(2)
-if (args.length === 0) opts.help = true
+if (args.length === 0) setAction('help')
 for (let i = 0; i < args.length; i++) {
   const parser = parsers.find((p) => p.arg.includes(args[i]))
 

--- a/libs/cy-reporter/src/cli/types.d.ts
+++ b/libs/cy-reporter/src/cli/types.d.ts
@@ -10,9 +10,7 @@ type ParserFlag =
 export type Parser = { arg: string[] } & ParserFlag
 
 export type Options = {
+  action: 'unset' | 'open' | 'run' | 'list' | 'help'
   force: boolean
   all: boolean
-  run: boolean
-  list: boolean
-  help: boolean
 }

--- a/libs/cy-reporter/src/reporters/sender.ts
+++ b/libs/cy-reporter/src/reporters/sender.ts
@@ -6,6 +6,8 @@ import { EventEmitter } from 'events'
 import { basename } from 'path'
 import type { Packet } from '../types'
 
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '1'
+
 /**
  * mini mutex
  *

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "test:dev": "yarn test:build && yarn test",
     "test:scan": "ts-node scripts/run-tests/scan.ts",
     "test:build": "yarn test:scan && node scripts/run-tests/build.js",
-    "e2e": "node scripts/cypress/open.js",
     "mg": "bash scripts/migration/generate.sh",
     "mr": "bash scripts/migration/run.sh",
     "tc": "bash scripts/migration/test-connect.sh",

--- a/package.scripts.js
+++ b/package.scripts.js
@@ -19,7 +19,6 @@ module.exports = {
   'test:dev': 'yarn test:build && yarn test',
   'test:scan': 'ts-node scripts/run-tests/scan.ts',
   'test:build': 'yarn test:scan && node scripts/run-tests/build.js',
-  e2e: 'node scripts/cypress/open.js',
   mg: 'bash scripts/migration/generate.sh',
   mr: 'bash scripts/migration/run.sh',
   tc: 'bash scripts/migration/test-connect.sh',

--- a/scripts/run-tests/help.ts
+++ b/scripts/run-tests/help.ts
@@ -1,4 +1,5 @@
-export const helpText = `modtree test runner
+export const helpText = `
+modtree test runner
 
 USAGE: yarn test [NAME | ALIAS | GROUP]
 `

--- a/scripts/runner.js
+++ b/scripts/runner.js
@@ -26,9 +26,9 @@ class Runner {
    * @param {webpack.Compiler} compiler
    * @param {string} script
    */
-  constructor(compiler, script) {
+  constructor(compiler, script = '') {
     this.#compiler = compiler
-    this.#script = resolve(compiler.outputPath, script)
+    this.#script = script ? resolve(compiler.outputPath, script) : ''
   }
 
   /**
@@ -46,12 +46,15 @@ class Runner {
    */
   watch() {
     this.#compiler.watch({ aggregateTimeout: 300 }, (_, s) => showErrors(s))
-    nodemon({ script: this.#script, watch: this.#compiler.outputPath })
-    nodemon
-      .on('quit', () => process.exit())
-      .on('restart', () => {
-        console.log(magenta('nodemon restarted', date()))
-      })
+    // run the script if it exists
+    if (this.#script) {
+      nodemon({ script: this.#script, watch: this.#compiler.outputPath })
+      nodemon
+        .on('quit', () => process.exit())
+        .on('restart', () => {
+          console.log(magenta('nodemon restarted', date()))
+        })
+    }
   }
 
   /**

--- a/scripts/runner.js
+++ b/scripts/runner.js
@@ -1,5 +1,6 @@
 const nodemon = require('nodemon')
 const webpack = require('webpack')
+const { EventEmitter } = require('events')
 const { resolve } = require('path')
 const { gray, magenta } = require('chalk')
 const date = () => new Date().toLocaleString()
@@ -45,16 +46,23 @@ class Runner {
    * run the build and watch for changes
    */
   watch() {
-    this.#compiler.watch({ aggregateTimeout: 300 }, (_, s) => showErrors(s))
-    // run the script if it exists
-    if (this.#script) {
-      nodemon({ script: this.#script, watch: this.#compiler.outputPath })
-      nodemon
-        .on('quit', () => process.exit())
-        .on('restart', () => {
-          console.log(magenta('nodemon restarted', date()))
-        })
-    }
+    const bus = new EventEmitter()
+    console.log(gray('building for the first time...'))
+    this.#compiler.watch({ aggregateTimeout: 300 }, (_, s) => {
+      showErrors(s)
+      bus.emit('built')
+    })
+    bus.once('built', () => {
+      // run the script if it exists
+      if (this.#script) {
+        nodemon({ script: this.#script, watch: this.#compiler.outputPath })
+        nodemon
+          .on('quit', () => process.exit())
+          .on('restart', () => {
+            console.log(magenta('nodemon restarted', date()))
+          })
+      }
+    })
   }
 
   /**


### PR DESCRIPTION
Working towards #406

### Summary of changes

- `yarn cy open` now opens Cypress GUI
- `yarn cy` help text reflects this

### Other changes

- dev tools that use `webpack` watch feature now awaits the first build before starting.
  - this eliminates the error shown when the server starts when the build output doesn't exist yet.